### PR TITLE
Allow the PK of an object to be used in the filename of images generated.

### DIFF
--- a/imagekit/specs.py
+++ b/imagekit/specs.py
@@ -83,7 +83,8 @@ class Accessor(object):
                 if issubclass(processor, processors.Format):
                     extension = processor.extension
             cache_filename = self._obj._ik.cache_filename_format % \
-                {'filename': filename,
+                {'pk': self._obj.pk,
+                 'filename': filename,
                  'specname': self.spec.name(),
                  'extension': extension.lstrip('.')}
             if callable(self._obj._ik.cache_dir):


### PR DESCRIPTION
Added the pk of the object into the dictionary of values passed to the string formatting for cache_filename in Accessor.name().
