### PR TITLE
Allow any field on the model to be used in the name of the generated images.

### DIFF
--- a/imagekit/options.py
+++ b/imagekit/options.py
@@ -13,6 +13,7 @@ class Options(object):
     preprocessor_spec = None
     cache_dir = 'cache'
     save_count_as = None
+    cache_filename_fields = ['pk', ]
     cache_filename_format = "%(filename)s_%(specname)s.%(extension)s"
     admin_thumbnail_spec = 'admin_thumbnail'
     spec_module = 'imagekit.defaults'

--- a/imagekit/specs.py
+++ b/imagekit/specs.py
@@ -82,11 +82,17 @@ class Accessor(object):
             for processor in self.spec.processors:
                 if issubclass(processor, processors.Format):
                     extension = processor.extension
+            filename_format_dict = {'filename': filename,
+                                    'specname': self.spec.name(),
+                                    'extension': extension.lstrip('.')}
+            cache_filename_fields = self._obj._ik.cache_filename_fields
+            filename_format_dict.update(dict(zip(
+                        cache_filename_fields,
+                        [getattr(self._obj, field) for
+                         field in cache_filename_fields])))
             cache_filename = self._obj._ik.cache_filename_format % \
-                {'pk': self._obj.pk,
-                 'filename': filename,
-                 'specname': self.spec.name(),
-                 'extension': extension.lstrip('.')}
+                filename_format_dict
+
             if callable(self._obj._ik.cache_dir):
                 return self._obj._ik.cache_dir(self._obj, filepath,
                                                cache_filename)


### PR DESCRIPTION
Options now has an attribute 'cache_filename_fields' which is a list of fields on the model that will be accessible for naming generated images. Defaults to ['pk',].
