### PR TITLE
Minor improvement to fault tolerance of Accessor._delete()

### DIFF
--- a/imagekit/specs.py
+++ b/imagekit/specs.py
@@ -68,7 +68,10 @@ class Accessor(object):
 
     def _delete(self):
         if self._obj._imgfield:
-            self._obj._storage.delete(self.name)
+            try:
+                self._obj._storage.delete(self.name)
+            except (NotImplementedError, IOError):
+                return
 
     def _exists(self):
         if self._obj._imgfield:


### PR DESCRIPTION
Handle/ ignore NotImplementedError and IOError which might get thrown
by the storage backend on delete.

I noticed that some storage backends throw an IOError on delete if a file does not exist, or do not at all check for a file's existence before deleting. Also, Django storage backends may choose to not support object deletion. With this fix, imagekit will no longer crash in these two cases, for example upon _clear_cache().
