### PR TITLE
Added ability to specify specs in IKOptions directly.

### DIFF
--- a/imagekit/models.py
+++ b/imagekit/models.py
@@ -44,17 +44,18 @@ class ImageModelBase(ModelBase):
             return
         user_opts = getattr(cls, 'IKOptions', None)
         opts = Options(user_opts)
-        try:
-            module = __import__(opts.spec_module,  {}, {}, [''])
-        except ImportError:
-            raise ImportError('Unable to load imagekit config module: %s' % \
-                opts.spec_module)
-        for spec in [spec for spec in module.__dict__.values() \
-                     if isinstance(spec, type) \
-                     and issubclass(spec, specs.ImageSpec) \
-                     and spec != specs.ImageSpec]:
+        if not opts.specs:
+            try:
+                module = __import__(opts.spec_module,  {}, {}, [''])
+            except ImportError:
+                raise ImportError('Unable to load imagekit config module: %s' \
+                    % opts.spec_module)
+            opts.specs.extend([spec for spec in module.__dict__.values() \
+                    if isinstance(spec, type) \
+                    and issubclass(spec, specs.ImageSpec) \
+                    and spec != specs.ImageSpec])
+        for spec in opts.specs:
             setattr(cls, spec.name(), specs.Descriptor(spec))
-            opts.specs.append(spec)
         setattr(cls, '_ik', opts)
 
 

--- a/imagekit/options.py
+++ b/imagekit/options.py
@@ -17,9 +17,10 @@ class Options(object):
     cache_filename_format = "%(filename)s_%(specname)s.%(extension)s"
     admin_thumbnail_spec = 'admin_thumbnail'
     spec_module = 'imagekit.defaults'
+    specs = None
     #storage = defaults to image_field.storage
 
     def __init__(self, opts):
         for key, value in opts.__dict__.iteritems():
             setattr(self, key, value)
-            self.specs = []
+        self.specs = list(self.specs or [])


### PR DESCRIPTION
It seems a little weird to me that you have to create a module just to provide a list of specs to IKOptions. Using a module as a collection like that also makes it unnecessarily difficult to share specs between ImageModel subclasses. This change lets you specify the specs as a list in your nested IKConfig class. For example:

```
from django.db import models
from imagekit.models import ImageModel
from myapp.specs import Thumbnail, Display

class Photo(ImageModel):
    name = models.CharField(max_length=100)
    original_image = models.ImageField(upload_to='photos')
    num_views = models.PositiveIntegerField(editable=False, default=0)

    class IKOptions:
        # This inner class is where we define the ImageKit options for the model
        specs = [Thumbnail, Display]
        cache_dir = 'photos'
        image_field = 'original_image'
        save_count_as = 'num_views'
```

If `specs` isn't provided, it will try to use `spec_module`.
