### PR TITLE
Trasparency preservation patch 

### DIFF
--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -7,7 +7,7 @@ def img_to_fobj(img, format, **kwargs):
     
     #preserve transparency if the image is in Pallette (P) mode
     if img.mode == 'P':
-        kwargs['transparency'] = 255
+        kwargs['transparency'] = len(img.split()[-1].getcolors())
     else:
         img.convert('RGB')
     


### PR DESCRIPTION
I changed the img_to_fobj function in utils.py to maintain "P" (palette) mode after conversion. Helps to preserve transparent layers, instead of converting everything to RGB before calling save()
