### PR TITLE
Changed id to pk in case the primary key isn't called 'id'

### DIFF
--- a/imagekit/management/commands/ikflush.py
+++ b/imagekit/management/commands/ikflush.py
@@ -25,7 +25,7 @@ def flush_cache(apps, options):
             models = [m for m in cache.get_models(app) if issubclass(m, ImageModel)]
             for model in models:
                 print 'Flushing cache for "%s.%s"' % (app_label, model.__name__)
-                for obj in model.objects.order_by('-id'):
+                for obj in model.objects.order_by('-pk'):
                     for spec in model._ik.specs:
                         prop = getattr(obj, spec.name(), None)
                         if prop is not None:


### PR DESCRIPTION
Running ikflush was breaking because my model didn't have in id field, the pk was called 'slug' this fixes that, and I don't think has any adverse effects. Also, out of curiosity, why is this call being ordered at all?
