### PR TITLE
Avoid Transpose to crash when there is no exif data

### DIFF
--- a/imagekit/processors/__init__.py
+++ b/imagekit/processors/__init__.py
@@ -163,7 +163,7 @@ class Transpose(object):
             try:
                 orientation = img._getexif()[0x0112]
                 ops = self._EXIF_ORIENTATION_STEPS[orientation]
-            except AttributeError:
+            except (TypeError, AttributeError):
                 ops = []
         else:
             ops = self.methods


### PR DESCRIPTION
When photo has no Exif data, `img._getexif()`return `None` and so `Transpose` crash, so catching TypeError avoid this.
