### PR TITLE
RGBA mode breaks transparency check

### DIFF
--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -11,8 +11,9 @@ def img_to_fobj(img, format, **kwargs):
 
     # Preserve transparency if the image is in Pallette (P) mode.
     transparency_formats = ('PNG', 'GIF', )
-    if img.mode == 'P' and format in transparency_formats:
-        kwargs['transparency'] = len(img.split()[-1].getcolors())
+    if format in transparency_formats:
+        if img.mode == 'P':
+            kwargs['transparency'] = len(img.split()[-1].getcolors())
     else:
         img = img.convert('RGB')
 


### PR DESCRIPTION
RGBA is a transparent image mode too . When saving RGBA, you cannot specify 'transparency' color - you get IOError wrong mode. 
