### PR TITLE
Rename `resize` Module to `scale`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,12 @@ your spec, you can expose different versions of the original image::
 
     from django.db import models
     from imagekit.models import ImageSpec
-    from imagekit.processors import resize, Adjust
+    from imagekit.processors import scale, Adjust
 
     class Photo(models.Model):
         original_image = models.ImageField(upload_to='photos')
         thumbnail = ImageSpec([Adjust(contrast=1.2, sharpness=1.1),
-                resize.Crop(50, 50)], image_field='original_image',
+                scale.Crop(50, 50)], image_field='original_image',
                 format='JPEG', options={'quality': 90})
 
 The ``thumbnail`` property will now return a cropped image::
@@ -61,7 +61,7 @@ The ``thumbnail`` property will now return a cropped image::
     photo.original_image.width # > 1000
 
 The original image is not modified; ``thumbnail`` is a new file that is the
-result of running the ``imagekit.processors.resize.Crop`` processor on the
+result of running the ``imagekit.processors.scale.Crop`` processor on the
 original.
 
 The ``imagekit.processors`` module contains processors for many common

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -15,7 +15,7 @@ API Reference
 .. automodule:: imagekit.processors
    :members:
 
-.. automodule:: imagekit.processors.resize
+.. automodule:: imagekit.processors.scale
   :members:
 
 

--- a/imagekit/processors/__init__.py
+++ b/imagekit/processors/__init__.py
@@ -8,7 +8,7 @@ from both the filesystem and the ORM.
 
 """
 from imagekit.lib import Image, ImageColor, ImageEnhance
-from imagekit.processors import resize
+from imagekit.processors import scale
 
 
 RGBA_TRANSPARENCY_FORMATS = ['PNG']

--- a/imagekit/processors/scale.py
+++ b/imagekit/processors/scale.py
@@ -1,4 +1,3 @@
-
 import math
 from imagekit.lib import Image
 
@@ -194,4 +193,3 @@ class SmartCrop(object):
         img = img.crop(box)
         
         return img
-

--- a/tests/core/tests.py
+++ b/tests/core/tests.py
@@ -9,7 +9,7 @@ from imagekit import utils
 from imagekit.lib import Image
 from imagekit.models import ImageSpec
 from imagekit.processors import Adjust
-from imagekit.processors.resize import Crop, SmartCrop
+from imagekit.processors.scale import Crop, SmartCrop
 
 
 class Photo(models.Model):


### PR DESCRIPTION
This is something that came up in #66 so I thought I'd create an issue for us to discuss it.

In summary, "resize" is a bit of a misnomer and the module probably should've been named "scale."

To avoid confusion with the new `crop` module (proposed in #66), we might also consider renaming `resize.Crop`—perhaps to `scale.Resize` or `scale.CropResize`—and `resize.SmartCrop`.

This breaks compatibility, so it would be a 1.1 change.
