### PR TITLE
Avoid Transpose to crash when exif data doesn't exists

### DIFF
--- a/imagekit/processors/__init__.py
+++ b/imagekit/processors/__init__.py
@@ -167,7 +167,7 @@ class Transpose(object):
             try:
                 orientation = img._getexif()[0x0112]
                 ops = self._EXIF_ORIENTATION_STEPS[orientation]
-            except (TypeError, AttributeError):
+            except (KeyError, TypeError, AttributeError):
                 ops = []
         else:
             ops = self.methods


### PR DESCRIPTION
Because catching `TypeError` wasn't enough (see #49), this should make it even more robust.
