### PR TITLE
Wrap ContentFile in a file-like object with a filename and content_type.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Contributors
 * `Timothée Peignier`_
 * `Madis Väin`_
 * `Jan Sagemüller`_
+* `Clay McClure`_
 
 .. _Justin Driscoll: http://github.com/jdriscoll
 .. _HZDG: http://hzdg.com
@@ -40,3 +41,4 @@ Contributors
 .. _Timothée Peignier: http://github.com/cyberdelia
 .. _Madis Väin: http://github.com/madisvain
 .. _Jan Sagemüller: https://github.com/version2
+.. _Clay McClure: https://github.com/claymation

--- a/imagekit/generators.py
+++ b/imagekit/generators.py
@@ -1,4 +1,6 @@
+import mimetypes
 import os
+
 from StringIO import StringIO
 
 from django.core.files.base import ContentFile
@@ -7,6 +9,23 @@ from .processors import ProcessorPipeline, AutoConvert
 from .utils import img_to_fobj, open_image, \
         format_to_extension, extension_to_format, UnknownFormatError, \
         UnknownExtensionError
+
+
+class SpecFile(ContentFile):
+    """
+    Wraps a ContentFile in a file-like object with a filename
+    and a content_type.
+    """
+    def __init__(self, filename, content):
+        self.file = ContentFile(content)
+        self.file.name = filename
+        try:
+            self.file.content_type = mimetypes.guess_type(filename)[0]
+        except IndexError:
+            self.file.content_type = None
+
+    def __str__(self):
+        return self.file.name
 
 
 class SpecFileGenerator(object):
@@ -50,7 +69,7 @@ class SpecFileGenerator(object):
                     options.items())
 
         imgfile = img_to_fobj(img, format, **options)
-        content = ContentFile(imgfile.read())
+        content = SpecFile(filename, imgfile.read())
         return img, content
 
     def suggest_extension(self, name):


### PR DESCRIPTION
We use ImageKit to scale images and Rackspace Cloud (formerly Mosso) to serve them. Unfortunately, we've found that our scaled images (spec files) are served with an incorrect Content-Type—`application/octet-stream`—causing browsers to download the images instead of displaying them. Our original source images, however, _are_ served with the correct Content-Type, and they are also hosted on Rackspace Cloud. So what gives?

When users upload files to our site, Django reads the content type from the multipart MIME header and sets a `content_type` attribute on the UploadedFile object created to handle the uploaded file. The django-storages Mosso back-end that we use then references that `content_type` attribute when posting the file to Rackspace Cloud, allowing that file to be served with the appropriate Content-Type header.

ImageKit does not set such an attribute, however, so neither django-storages nor the cloudfiles storage backend can set a content type when saving the spec files out to the cloud. This patch adds an extra layer of indirection that allows us to tack some attributes (`name` and `content_type`) onto the underlying `ContentFile`—which we can't do with `StringIO` since that's a native type.

I debated whether I should modify ImageKit, django-storages, or the cloudfiles backend, but ultimately decided ImageKit was the right place since django-storages and cloudfiles already provide mechanisms to set content type (by deferring to the content_type or name of the source file), and Django accommodates that by setting a content_type attribute on uploaded files. Setting name and content_type in ImageKit seems like a simple and inexpensive solution (work-around?) to the problem.
