### PR TITLE
Fix documentation build

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -5,7 +5,7 @@ API Reference
 :mod:`models` Module
 --------------------
 
-.. automodule:: imagekit.models
+.. automodule:: imagekit.models.fields
    :members:
 
 
@@ -13,13 +13,13 @@ API Reference
 ------------------------
 
 .. automodule:: imagekit.processors
-   :members:
+    :members:
 
 .. automodule:: imagekit.processors.resize
-  :members:
+    :members:
 
 .. automodule:: imagekit.processors.crop
-:members:
+    :members:
 
 
 :mod:`admin` Module

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ import sys, os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 sys.path.append(os.path.abspath('_themes'))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 
 # -- General configuration -----------------------------------------------------
 
@@ -121,7 +122,7 @@ html_theme_path = ['_themes']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,9 @@ Getting Started
 Commands
 --------
 
-.. automodule:: imagekit.management.commands.ikflush
+.. automodule:: imagekit.management.commands.ikcacheinvalidate
+
+.. automodule:: imagekit.management.commands.ikcachevalidate
 
 
 Authors


### PR DESCRIPTION
Build now include models fields documentation and the new commands (but documentation is empty for them), and doesn't break when trying to import django modules. 
