### PR TITLE
Delete file before re-generating it

### DIFF
--- a/imagekit/imagecache/celery.py
+++ b/imagekit/imagecache/celery.py
@@ -10,7 +10,9 @@ def generate(model, pk, attr):
     except model.DoesNotExist:
         pass  # The model was deleted since the task was scheduled. NEVER MIND!
     else:
-        getattr(instance, attr).generate(save=True)
+        field_file = getattr(instance, attr)
+        field_file.delete(save=False)
+        field_file.generate(save=True)
 
 
 class CeleryImageCacheBackend(PessimisticImageCacheBackend):


### PR DESCRIPTION
The actual celery backend doesn't try to delete file, so it tends to generate file ending like `_1.jpg` which is not the appropriate behavior.
