### PR TITLE
Do not leak file descriptor

### DIFF
--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -282,6 +282,7 @@ class quiet(object):
     def __exit__(self, *args, **kwargs):
         os.dup2(self.old, self.stderr_fd)
         os.close(self.null_fd)
+        os.close(self.old)
 
 
 def prepare_image(img, format):


### PR DESCRIPTION
The fiddling with stderr leaks a file descriptor with every PIL invocation because self.old isn't closed.
