### PR TITLE
Width and Height parameters do not require disk access if guess_size (a new parameter in the constructor) is True

### DIFF
--- a/imagekit/models/fields/__init__.py
+++ b/imagekit/models/fields/__init__.py
@@ -18,7 +18,7 @@ class ImageSpecField(object):
     """
     def __init__(self, processors=None, format=None, options=None,
         image_field=None, pre_cache=None, storage=None, cache_to=None,
-        autoconvert=True, image_cache_backend=None):
+        autoconvert=True, image_cache_backend=None, guess_size=False):
         """
         :param processors: A list of processors to run on the original image.
         :param format: The format of the output file. If not provided,
@@ -67,6 +67,7 @@ class ImageSpecField(object):
         p = lambda file: processors(instance=file.instance, file=file) if \
                 callable(processors) else processors
 
+        self.processors = [processors] if callable(processors) else processors
         self.generator = SpecFileGenerator(p, format=format, options=options,
                 autoconvert=autoconvert, storage=storage)
         self.image_field = image_field
@@ -74,6 +75,7 @@ class ImageSpecField(object):
         self.cache_to = cache_to
         self.image_cache_backend = image_cache_backend or \
                 get_default_image_cache_backend()
+        self.guess_size = guess_size
 
     def contribute_to_class(self, cls, name):
         setattr(cls, name, ImageSpecFileDescriptor(self, name))

--- a/imagekit/models/fields/files.py
+++ b/imagekit/models/fields/files.py
@@ -145,6 +145,22 @@ class ImageSpecFieldFile(ImageFieldFile):
         # it at least that one time.
         pass
 
+    @property
+    def width(self):
+        if self.field.guess_size:
+            for processor in self.field.processors:
+                if hasattr(processor, 'width') and processor.width:
+                    return processor.width
+        return super(ImageFieldFile, self).width
+
+    @property
+    def height(self):
+        if self.field.guess_size:
+            for processor in self.field.processors:
+                if hasattr(processor, 'height') and processor.height:
+                    return processor.height
+        return super(ImageFieldFile, self).height
+
 
 class ProcessedImageFieldFile(ImageFieldFile):
     def save(self, name, content, save=True):

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -13,6 +13,10 @@ class Photo(models.Model):
             ResizeToFill(50, 50)], image_field='original_image', format='JPEG',
             options={'quality': 90})
 
+    thumbnail_guess_size = ImageSpecField([Adjust(contrast=1.2, sharpness=1.1),
+            ResizeToFill(50, 50)], image_field='original_image', format='JPEG',
+            options={'quality': 90}, guess_size=True)
+
     smartcropped_thumbnail = ImageSpecField([Adjust(contrast=1.2,
             sharpness=1.1), SmartCrop(50, 50)], image_field='original_image',
             format='JPEG', options={'quality': 90})

--- a/tests/core/tests.py
+++ b/tests/core/tests.py
@@ -3,6 +3,8 @@ from __future__ import with_statement
 import os
 import pickle
 
+from mock import Mock
+
 from django.test import TestCase
 
 from imagekit import utils
@@ -53,6 +55,15 @@ class IKTest(TestCase):
     def test_thumbnail_source_file(self):
         self.assertEqual(
             self.photo.thumbnail.source_file, self.photo.original_image)
+
+    def test_guess_size(self):
+        _tmp_photo_thumbnail = self.photo.thumbnail_guess_size
+        _tmp_photo_thumbnail._get_image_dimensions = Mock()
+
+        self.assertEqual(_tmp_photo_thumbnail.width, 50)
+        self.assertEqual(_tmp_photo_thumbnail.height, 50)
+
+        assert not _tmp_photo_thumbnail._get_image_dimensions.called
 
 
 class IKUtilsTest(TestCase):


### PR DESCRIPTION
Sometimes hitting the disk is expensive, and this patch allows the developer to pass guess_size as a parameter into the constructor, so that width and height do not hit the disk.
