### PR TITLE
Add is_valid method to Spec class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,12 +149,12 @@ exists means frequently hitting the storage backend.
 
 Because of this, ImageKit allows you to define custom image cache backends. To
 be a valid image cache backend, a class must implement three methods:
-``validate``, ``invalidate``, and ``clear`` (which is called when the image is
-no longer needed in any form, i.e. the model is deleted). Each of these methods
-must accept a file object, but the internals are up to you. For example, you
-could store the state (valid, invalid) of the cache in a database to avoid
-filesystem access. You can then specify your image cache backend on a per-field
-basis::
+``validate``, ``invalidate``, ``is_valid`` and ``clear`` (which is called when
+the image is no longer needed in any form, i.e. the model is deleted). Each of
+these methods must accept a file object, but the internals are up to you. For
+example, you could store the state (valid, invalid) of the cache in a database
+to avoid filesystem access. You can then specify your image cache backend on a
+per-field basis::
 
     class Photo(models.Model):
         ...

--- a/imagekit/imagecache/base.py
+++ b/imagekit/imagecache/base.py
@@ -12,18 +12,18 @@ class PessimisticImageCacheBackend(object):
 
     """
 
-    def is_invalid(self, file):
-        if not getattr(file, '_file', None):
-            # No file on object. Have to check storage.
-            return not file.storage.exists(file.name)
-        return False
+    def is_valid(self, file):
+        if getattr(file, '_file', None):
+            return True
+        # No file on object. Have to check storage.
+        return file.storage.exists(file.name)
 
     def validate(self, file):
         """
         Generates a new image by running the processors on the source file.
 
         """
-        if self.is_invalid(file):
+        if not self.is_valid(file):
             file.generate(save=True)
 
     def invalidate(self, file):
@@ -41,6 +41,12 @@ class NonValidatingImageCacheBackend(object):
     after validation.
 
     """
+
+    def is_valid(self, file):
+        if getattr(file, '_file', None):
+            return True
+        # No file on object. Have to check storage.
+        return file.storage.exists(file.name)
 
     def validate(self, file):
         """

--- a/imagekit/models/fields/files.py
+++ b/imagekit/models/fields/files.py
@@ -50,6 +50,9 @@ class ImageSpecFieldFile(ImageFieldFile):
     def validate(self):
         return self.field.image_cache_backend.validate(self)
 
+    def is_valid(self):
+        return self.field.image_cache_backend.is_valid(self)
+
     def generate(self, save=True):
         """
         Generates a new image file by processing the source file and returns


### PR DESCRIPTION
This change adds the method is_valid to the Spec class. I'm using the celery backend to generate thumbnails and when a lot of images get uploaded at once not all thumbnails are available when a page is requested right after the upload. The is_valid method makes it possible to check whether the image is available and do something else in case it isn't, instead of taking a lot of time and resources to generate the thumbnails in the page request. You could for example use it in a template to show a placeholder image when a thumbnail isn't available:

```
{% if image.thumbnail.is_valid %}
<img src="{{ image.thumbnail.url }}" ... 
{% else %}
<img src="placeholder.jpg" ...
{% endif %}
```
