### PR TITLE
One solution to Issue #138: 

### DIFF
--- a/imagekit/admin.py
+++ b/imagekit/admin.py
@@ -10,28 +10,39 @@ class AdminThumbnail(object):
     short_description = _('Thumbnail')
     allow_tags = True
 
-    def __init__(self, image_field, template=None):
+    def __init__(self, image_field, template=None, image_fk=None):
         """
         :param image_field: The name of the ImageField or ImageSpecField on the
             model to use for the thumbnail.
         :param template: The template with which to render the thumbnail
+        :param image_fk: The name of the filed that links to the ImageField
 
         """
         self.image_field = image_field
         self.template = template
+        self.image_fk = image_fk
 
     def __call__(self, obj):
-        try:
-            thumbnail = getattr(obj, self.image_field)
-        except AttributeError:
-            raise Exception('The property %s is not defined on %s.' % \
-                    (self.image_field, obj.__class__.__name__))
+        #Test for image_fk
+        if self.image_fk == None:
+            thumbnail = getattr(obj, self.image_field, None)
+        else:
+            thumbnail = getattr(getattr(obj, self.image_fk), self.image_field, None)
+
+        if not thumbnail:
+            try:
+                thumbnail = getattr(obj, self.image_field)
+            except AttributeError:
+                raise Exception('The property %s is not defined on %s.' % \
+                        (self.image_field, obj.__class__.__name__))
 
         original_image = getattr(thumbnail, 'source_file', None) or thumbnail
         template = self.template or 'imagekit/admin/thumbnail.html'
+
 
         return render_to_string(template, {
             'model': obj,
             'thumbnail': thumbnail,
             'original_image': original_image,
         })
+


### PR DESCRIPTION
`__init__` accepts `image_fk` arg in order to allow thumbnail to be displayed within inline forms; `__call__` then tests for the argument.

Another option is to provide the `image_field` in a dot format: e.g. image.thumbnail

``` python
def __call__(self, obj):

    if self.image_field.find('.') == -1:
        thumbnail = getattr(obj, self.image_field, None)
    else:
        thumbnail = getattr(getattr(obj, self.image_field.split('.')[0]), self.image_field.split('.')[1], None)
    ...

```

However, thought the dot notation could be a little confusing and went with the additional arg
