### PR TITLE
Fix API documentation

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -5,7 +5,7 @@ API Reference
 :mod:`models` Module
 --------------------
 
-.. automodule:: imagekit.models
+.. automodule:: imagekit.models.fields
    :members:
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.abspath('_themes'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-Django >= 1.3.1
+Django>=1.3.1
+django-appconf>=0.5
+PIL>=1.1.7


### PR DESCRIPTION
This is a fix for #143, it also need to change readthedocs configuration to use the requirements.txt file.
