### PR TITLE
Abstract models containing ImageSpecFields are not handled properly

### DIFF
--- a/imagekit/specs/sourcegroups.py
+++ b/imagekit/specs/sourcegroups.py
@@ -15,6 +15,7 @@ from django.db.models.signals import post_init, post_save, post_delete
 from django.utils.functional import wraps
 from ..cachefiles import LazyImageCacheFile
 from ..signals import source_created, source_changed, source_deleted
+from ..utils import get_nonabstract_descendants
 
 
 def ik_model_receiver(fn):
@@ -131,8 +132,9 @@ class ImageFieldSourceGroup(object):
         particular model.
 
         """
-        for instance in self.model_class.objects.all():
-            yield getattr(instance, self.image_field)
+        for model in get_nonabstract_descendants(self.model_class):
+            for instance in model.objects.all().iterator():
+                yield getattr(instance, self.image_field)
 
 
 class SourceGroupFilesGenerator(object):

--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -23,6 +23,17 @@ def _get_models(apps):
     return models
 
 
+def get_nonabstract_descendants(model):
+    """ Returns all non-abstract descendants of the model. """
+    if model._meta.abstract:
+        descendants = []
+        for m in model.__subclasses__():
+            descendants += get_nonabstract_descendants(m)
+        return descendants
+    else:
+        return [model]
+
+
 def get_by_qname(path, desc):
     try:
         dot = path.rindex('.')


### PR DESCRIPTION
One of my models is abstract and includes several `ImageSpecField` fields.  Calling `./manage.py generateimages` leads to an exception in `imagekit/specs/sourcegroups.py` at the line:

```
    for instance in self.model_class.objects.all():
```

The attached commit fixes this particular exception, but I don't think it addresses all the potential issues involved with abstract base classes.  For example, the generator registry only includes one entry corresponding to the abstract base; it may make sense to instead list it for all the descendants that correspond to non-abstract models.
