### PR TITLE
Re-open source file on ValueError in ImageSpec.generate()

### DIFF
--- a/imagekit/specs/__init__.py
+++ b/imagekit/specs/__init__.py
@@ -130,7 +130,14 @@ class ImageSpec(BaseImageSpec):
 
         # TODO: Move into a generator base class
         # TODO: Factor out a generate_image function so you can create a generator and only override the PIL.Image creating part. (The tricky part is how to deal with original_format since generator base class won't have one.)
-        img = open_image(self.source)
+        try:
+            img = open_image(self.source)
+        except ValueError:
+
+            # Re-open the file -- https://code.djangoproject.com/ticket/13750
+            self.source.open()
+            img = open_image(self.source)
+
         original_format = img.format
 
         # Run the processors


### PR DESCRIPTION
This is a workaround for a Django issue described here:  https://code.djangoproject.com/ticket/13750

When using an `ImageSpecField` with a source `ImageField` that has `width_field` & `height_field` params, Django sets the width/height fields before IK gets to the file, and by that point it's closed and an I/O `ValueError` gets raised. 

This was initially discussed in matthewwithanm/pilkit#2
