### PR TITLE
Fixed thumbnail template tag treating provided sizes as strings, not integers

### DIFF
--- a/imagekit/templatetags/imagekit.py
+++ b/imagekit/templatetags/imagekit.py
@@ -28,7 +28,7 @@ def parse_dimensions(dimensions):
     will be None for that value.
 
     """
-    width, height = [d.strip() or None for d in dimensions.split('x')]
+    width, height = [d.strip() and int(d) or None for d in dimensions.split('x')]
     return dict(width=width, height=height)
 
 


### PR DESCRIPTION
Fixed thumbnail template tag treating provided sizes as strings, not integers.

This closes #217.

I did not add the regression test because the only available media file is 512x512 lenna.png, which can not be used to demonstrate the problem (a portrait or landscape image is required). I can add the test if you are okay if I replace lenna.png with a different image, or simply crop it to be, say, 384x512, or make a 1024x512 sprite of two Lennas.
