### PR TITLE
Add __getstate__ method to ImageCacheFile

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -1,3 +1,4 @@
+from copy import copy
 from django.conf import settings
 from django.core.files import File
 from django.core.files.images import ImageFile
@@ -128,6 +129,14 @@ class ImageCacheFile(BaseIKFile, ImageFile):
         # file exists. This gives the strategy a chance to create the file.
         existence_required.send(sender=self, file=self)
         return self.cachefile_backend.exists(self)
+
+    def __getstate__(self):
+        state = copy(self.__dict__)
+
+        # file is hidden link to "file" attribute
+        state.pop('_file', None)
+
+        return state
 
 
 class LazyImageCacheFile(SimpleLazyObject):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,7 +4,9 @@ deserialized. This is important when using IK with Celery.
 
 """
 
-from .utils import create_photo, pickleback
+from imagekit.cachefiles import ImageCacheFile
+from .imagegenerators import TestSpec
+from .utils import create_photo, pickleback, get_unique_image_file
 
 
 def test_imagespecfield():
@@ -23,3 +25,13 @@ def test_circular_ref():
     instance = create_photo('pickletest3.jpg')
     instance.thumbnail  # Cause thumbnail to be added to instance's __dict__
     pickleback(instance)
+	
+
+def test_cachefiles():
+    spec = TestSpec(source=get_unique_image_file())
+    file = ImageCacheFile(spec)
+    file.url
+    # remove link to file from spec source generator
+    # test __getstate__ of ImageCacheFile
+    file.generator.source = None
+    pickleback(file)


### PR DESCRIPTION
Add **getstate** method to ImageCacheFile
Fails when create new image preview in ImageSpecField filed in model and then pickle object
