### PR TITLE
Fixed #266 -- Simplified (and renamed) StrategyWrapper.

### DIFF
--- a/imagekit/cachefiles/strategies.py
+++ b/imagekit/cachefiles/strategies.py
@@ -36,24 +36,11 @@ class DictStrategy(object):
             setattr(self, k, v)
 
 
-class StrategyWrapper(LazyObject):
-    def __init__(self, strategy):
-        if isinstance(strategy, six.string_types):
-            strategy = get_singleton(strategy, 'cache file strategy')
-        elif isinstance(strategy, dict):
-            strategy = DictStrategy(strategy)
-        elif callable(strategy):
-            strategy = strategy()
-        self._wrapped = strategy
-
-    def __getstate__(self):
-        return {'_wrapped': self._wrapped}
-
-    def __setstate__(self, state):
-        self._wrapped = state['_wrapped']
-
-    def __unicode__(self):
-        return force_text(self._wrapped)
-
-    def __str__(self):
-        return str(self._wrapped)
+def load_strategy(strategy):
+    if isinstance(strategy, six.string_types):
+        strategy = get_singleton(strategy, 'cache file strategy')
+    elif isinstance(strategy, dict):
+        strategy = DictStrategy(strategy)
+    elif callable(strategy):
+        strategy = strategy()
+    return strategy

--- a/imagekit/specs/__init__.py
+++ b/imagekit/specs/__init__.py
@@ -2,7 +2,7 @@ from copy import copy
 from django.conf import settings
 from django.db.models.fields.files import ImageFieldFile
 from ..cachefiles.backends import get_default_cachefile_backend
-from ..cachefiles.strategies import StrategyWrapper
+from ..cachefiles.strategies import load_strategy
 from .. import hashers
 from ..exceptions import AlreadyRegistered, MissingSource
 from ..utils import open_image, get_by_qname, process_image
@@ -36,7 +36,7 @@ class BaseImageSpec(object):
 
     def __init__(self):
         self.cachefile_backend = self.cachefile_backend or get_default_cachefile_backend()
-        self.cachefile_strategy = StrategyWrapper(self.cachefile_strategy)
+        self.cachefile_strategy = load_strategy(self.cachefile_strategy)
 
     def generate(self):
         raise NotImplementedError


### PR DESCRIPTION
StrategyWrapper was unnecessarily implemented as a LazyObject
and it triggered a bug in Django (issue 21840).

Changing the lazy object to a function works just as well and
bypasses the bug.
