### PR TITLE
Django 1.7 support, fix for Django Ticket #21057

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -98,14 +98,10 @@ class ImageCacheFile(BaseIKFile, ImageFile):
 
         actual_name = self.storage.save(self.name, content)
 
-        # We're going to reuse the generated file, so we need to reset the pointer.
-        content.seek(0)
-
         # Store the generated file. If we don't do this, the next time the
         # "file" attribute is accessed, it will result in a call to the storage
-        # backend (in ``BaseIKFile._get_file``). Since we already have the
-        # contents of the file, what would the point of that be?
-        self.file = File(content)
+        # backend (in ``BaseIKFile._get_file``).
+        self.file = File(open(self.path))
 
         if actual_name != self.name:
             get_logger().warning(


### PR DESCRIPTION
Django's FileField used to leave temporary files around. ImageKit made use of this by not re-opening the file. This bug was fixed in https://code.djangoproject.com/ticket/21057 though, so content.seek(0) will fail (content is unlinked during self.storage.save()).

I'm not sure if this is the best way to do this, but just want to draw your attention to this issue.

Here is the commit that broke it:
https://github.com/django/django/commit/30fc49a7ca0d030c7855f31ed44395903fa6abdd