### PR TITLE
Fix for Django 1.7

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -95,17 +95,7 @@ class ImageCacheFile(BaseIKFile, ImageFile):
     def _generate(self):
         # Generate the file
         content = generate(self.generator)
-
         actual_name = self.storage.save(self.name, content)
-
-        # We're going to reuse the generated file, so we need to reset the pointer.
-        content.seek(0)
-
-        # Store the generated file. If we don't do this, the next time the
-        # "file" attribute is accessed, it will result in a call to the storage
-        # backend (in ``BaseIKFile._get_file``). Since we already have the
-        # contents of the file, what would the point of that be?
-        self.file = File(content)
 
         if actual_name != self.name:
             get_logger().warning(


### PR DESCRIPTION
Django 1.7 now properly closes tmp file.  Must hit storage backend to get file.