### PR TITLE
Option to suppress exceptions with templatetags 

### DIFF
--- a/imagekit/exceptions.py
+++ b/imagekit/exceptions.py
@@ -14,7 +14,7 @@ class MissingGeneratorId(Exception):
 
 
 class MissingSource(ValueError):
-    pass
+    silent_variable_failure = True
 
 
 # Aliases for backwards compatibility


### PR DESCRIPTION
I have code like this in the template:

```
{% thumbnail '588x344' idea.image as thumb %}
<img src="{{ thumb.url }}" alt="{{ idea.title }}" image-ratio />
```

This will cause a 500 error if the source image is missing. This commonly happens during development when the database and media dir get out of sync.

IMHO there should be a way for this to easily return a 404, converting it from an error which completely breaks the page into a more appropriate 'broken image' icon from the browser. 
