### PR TITLE
Fix a Django 1.7 issue with importing INSTALLED_APPS modules

### DIFF
--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -76,16 +76,21 @@ def autodiscover():
     _autodiscovered = True
 
     for app in settings.INSTALLED_APPS:
-        mod = import_module(app)
-        # Attempt to import the app's admin module.
+        # As of Django 1.7, settings.INSTALLED_APPS may contain classes instead of modules, hence the try/except
+        # See here: https://docs.djangoproject.com/en/dev/releases/1.7/#introspecting-applications
         try:
-            import_module('%s.imagegenerators' % app)
-        except:
-            # Decide whether to bubble up this error. If the app just
-            # doesn't have an imagegenerators module, we can ignore the error
-            # attempting to import it, otherwise we want it to bubble up.
-            if module_has_submodule(mod, 'imagegenerators'):
-                raise
+            mod = import_module(app)
+            # Attempt to import the app's admin module.
+            try:
+                import_module('%s.imagegenerators' % app)
+            except:
+                # Decide whether to bubble up this error. If the app just
+                # doesn't have an imagegenerators module, we can ignore the error
+                # attempting to import it, otherwise we want it to bubble up.
+                if module_has_submodule(mod, 'imagegenerators'):
+                    raise
+        except ImportError:
+            pass
 
 
 def get_logger(logger_name='imagekit', add_null_handler=True):


### PR DESCRIPTION
I ran into this issue because I was trying to use the new [SimpleAdminConfig](http://django.readthedocs.org/en/1.7.x/ref/contrib/admin/index.html#django.contrib.admin.apps.SimpleAdminConfig) in Django 1.7. Now that INSTALLED_APPS can contain classes (and not just modules), a possible ImportError needs to be caught within the preview autodiscover function.

According to the 1.7 release notes, the proper way to access "INSTALLED_APPS" is through the new "App registry", but if we did that here then imagekit would become incompatible with previous versions of Django.
