### PR TITLE
Explicitly setting serializer for celery task

### DIFF
--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -144,7 +144,7 @@ try:
 except ImportError:
     pass
 else:
-    _celery_task = task(ignore_result=True)(_generate_file)
+    _celery_task = task(ignore_result=True, serializer='pickle')(_generate_file)
 
 
 class Celery(BaseAsync):
@@ -153,7 +153,7 @@ class Celery(BaseAsync):
     """
     def __init__(self, *args, **kwargs):
         try:
-            import celery
+            import celery  # noqa
         except ImportError:
             raise ImproperlyConfigured('You must install celery to use'
                                        ' imagekit.cachefiles.backends.Celery.')
@@ -185,7 +185,7 @@ class RQ(BaseAsync):
     """
     def __init__(self, *args, **kwargs):
         try:
-            import django_rq
+            import django_rq  # noqa
         except ImportError:
             raise ImproperlyConfigured('You must install django-rq to use'
                                        ' imagekit.cachefiles.backends.RQ.')


### PR DESCRIPTION
Explicitly setting the celery task serializer to pickle, since it fails if the `CELERY_TASK_SERIALIZER` configuration setting is set to something else (for example json). 