### PR TITLE
Fix #317 RemovedInDjango19Warning: 'get_cache'

### DIFF
--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -1,7 +1,6 @@
-from ..utils import get_singleton, sanitize_cache_key
+from ..utils import get_singleton, get_cache, sanitize_cache_key
 import warnings
 from copy import copy
-from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
 
 


### PR DESCRIPTION
Make a `get_cache` function in `utils` which will call `django.core.cache.get_cache` if we are running Django < 1.7 or will mimic it's behaviour for newer versions of Django.