### PR TITLE
Add test environments for Python3.4 and Django1.7 and Django1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
     include_package_data=True,
     tests_require=[
         'beautifulsoup4==4.1.3',
-        'nose==1.3.0',
-        'nose-progressive==1.5',
-        'django-nose==1.2',
+        'nose>=1.3.6,<1.4',
+        'nose-progressive==1.5.1',
+        'django-nose>=1.2,<=1.4',
         'Pillow<3.0',
         'mock==1.0.1',
     ],
@@ -67,10 +67,13 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Utilities'
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,7 +34,6 @@ INSTALLED_APPS = [
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = [
     '-s',
-    '--with-progressive',
 
     # When the tests are run --with-coverage, these args configure coverage
     # reporting (requires coverage to be installed).
@@ -44,6 +43,9 @@ NOSE_ARGS = [
     '--cover-package=imagekit',
     '--cover-html-dir=%s' % os.path.join(BASE_PATH, 'cover')
 ]
+
+if os.getenv('TERM'):
+    NOSE_ARGS.append('--with-progressive')
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -26,6 +26,7 @@ def test_form_processedimagefield():
 
         class Meta:
             model = ImageModel
+            fields = 'image',
 
     upload_file = get_image_file()
     file_dict = {'image': SimpleUploadedFile('abc.jpg', upload_file.read())}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,42 @@
 [tox]
 envlist =
-    py33-django16, py33-django15,
-    py32-django16, py32-django15,
-    py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
+    py34-django18, py34-django17, py34-django16,
+    py33-django18, py33-django17, py33-django16, py33-django15,
+    py32-django18, py32-django17, py32-django16, py32-django15,
+    py27-django18, py27-django17, py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
     py26-django15, py26-django14, py26-django13, py26-django12
 
 [testenv]
 commands = python setup.py test
+
+[testenv:py34-django18]
+basepython = python3.4
+deps =
+    Django>=1.8,<1.9
+    django-nose==1.4
+
+[testenv:py34-django17]
+basepython = python3.4
+deps =
+    Django>=1.7,<1.8
+    django-nose==1.4
+
+[testenv:py34-django16]
+basepython = python3.4
+deps =
+    Django>=1.6,<1.7
+
+[testenv:py33-django18]
+basepython = python3.3
+deps =
+    Django>=1.8,<1.9
+    django-nose==1.4
+
+[testenv:py33-django17]
+basepython = python3.3
+deps =
+    Django>=1.7,<1.8
+    django-nose==1.4
 
 [testenv:py33-django16]
 basepython = python3.3
@@ -18,6 +48,18 @@ basepython = python3.3
 deps =
     Django>=1.5,<1.6
 
+[testenv:py32-django18]
+basepython = python3.4
+deps =
+    Django>=1.8,<1.9
+    django-nose==1.4
+
+[testenv:py32-django17]
+basepython = python3.4
+deps =
+    Django>=1.7,<1.8
+    django-nose==1.4
+
 [testenv:py32-django16]
 basepython = python3.2
 deps =
@@ -27,6 +69,18 @@ deps =
 basepython = python3.2
 deps =
     Django>=1.5,<1.6
+
+[testenv:py27-django18]
+basepython = python2.7
+deps =
+    Django>=1.8,<1.9
+    django-nose==1.4
+
+[testenv:py27-django17]
+basepython = python2.7
+deps =
+    Django>=1.7,<1.8
+    django-nose==1.4
 
 [testenv:py27-django16]
 basepython = python2.7
@@ -47,11 +101,13 @@ deps =
 basepython = python2.7
 deps =
     Django>=1.3,<1.4
+    django-nose==1.2
 
 [testenv:py27-django12]
 basepython = python2.7
 deps =
     Django>=1.2,<1.3
+    django-nose==1.2
 
 [testenv:py26-django15]
 basepython = python2.6
@@ -67,8 +123,10 @@ deps =
 basepython = python2.6
 deps =
     Django>=1.3,<1.4
+    django-nose==1.2
 
 [testenv:py26-django12]
 basepython = python2.6
 deps =
     Django>=1.2,<1.3
+    django-nose==1.2


### PR DESCRIPTION
`django-imagkit` support Python3.4 and newer Django versions. Now make it officially.