### PR TITLE
Close files

### DIFF
--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -96,6 +96,7 @@ class CachedFileBackend(object):
             self.set_state(file, CacheFileState.GENERATING)
             file._generate()
             self.set_state(file, CacheFileState.EXISTS)
+            file.close()
 
 
 class Simple(CachedFileBackend):

--- a/imagekit/specs/__init__.py
+++ b/imagekit/specs/__init__.py
@@ -153,9 +153,11 @@ class ImageSpec(BaseImageSpec):
             self.source.open()
             img = open_image(self.source)
 
-        return process_image(img, processors=self.processors,
-                             format=self.format, autoconvert=self.autoconvert,
-                             options=self.options)
+        new_image =  process_image(img, processors=self.processors,
+                                   format=self.format, autoconvert=self.autoconvert,
+                                   options=self.options)
+        self.source.close()
+        return new_image
 
 
 def create_spec_class(class_attrs):


### PR DESCRIPTION
In a processes that generates many images, you could run into a situation with too man files being open. This results in:
`IOError: [Errno 24] Too many open files`

This PR fixes the issue