### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,11 @@ matrix:
   allow_failures:
     - env: TOX_ENV=py35-django19
 
-install: pip install tox --use-mirrors
-script: tox
+install:
+  - pip install tox --use-mirrors
+
+script:
+  - tox -e $TOX_ENV
+
 notifications:
   irc: "irc.freenode.org#imagekit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-python:
-  - 2.7
+python: "2.7"
+sudo: false
 
 env:
   - TOX_ENV=py26-django12

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
 
 matrix:
   # Python 3.5 not yet available on travis, watch this to see when it is.
+  fast_finish: true
   allow_failures:
     - env: TOX_ENV=py35-django19
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,35 @@
 language: python
 python:
   - 2.7
+
+env:
+  - TOX_ENV=py26-django12
+  - TOX_ENV=py26-django13
+  - TOX_ENV=py26-django14
+  - TOX_ENV=py26-django15
+  - TOX_ENV=py26-django16
+  - TOX_ENV=py27-django12
+  - TOX_ENV=py27-django13
+  - TOX_ENV=py27-django14
+  - TOX_ENV=py27-django15
+  - TOX_ENV=py27-django16
+  - TOX_ENV=py27-django17
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py32-django15
+  - TOX_ENV=py32-django16
+  - TOX_ENV=py32-django17
+  - TOX_ENV=py32-django18
+  - TOX_ENV=py33-django15
+  - TOX_ENV=py33-django16
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py33-django18
+  - TOX_ENV=py34-django16
+  - TOX_ENV=py34-django17
+  - TOX_ENV=py34-django18
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py35-django19
+
 install: pip install tox --use-mirrors
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ env:
   - TOX_ENV=py34-django19
   - TOX_ENV=py35-django19
 
+matrix:
+  # Python 3.5 not yet available on travis, watch this to see when it is.
+  allow_failures:
+    - env: TOX_ENV=py35-django19
+
 install: pip install tox --use-mirrors
 script: tox
 notifications:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -44,11 +44,15 @@ Settings
 
 .. attribute:: IMAGEKIT_CACHE_BACKEND
 
-    :default: If ``DEBUG`` is ``True``, ``'django.core.cache.backends.dummy.DummyCache'``.
-    Otherwise, ``'default'``.
+    :default:  ``'default'``
 
-    The Django cache backend to be used to store information like the state of
-    cached images (i.e. validated or not).
+    The Django cache backend alias to retrieve the shared cache instance defined
+    in your settings, as described in the `Django cache section`_.
+
+    The cache is then used to store information like the state of cached
+    images (i.e. validated or not).
+
+.. _`Django cache section`: https://docs.djangoproject.com/en/1.8/topics/cache/#accessing-the-cache
 
 
 .. attribute:: IMAGEKIT_CACHE_PREFIX

--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -1,7 +1,6 @@
-from ..utils import get_singleton, sanitize_cache_key
+from ..utils import get_singleton, get_cache, sanitize_cache_key
 import warnings
 from copy import copy
-from django.core.cache import get_cache
 from django.core.exceptions import ImproperlyConfigured
 
 

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -17,25 +17,16 @@ class ImageKitConf(AppConf):
 
     def configure_cache_backend(self, value):
         if value is None:
-            try:
-                from django.core.cache.backends.dummy import DummyCache
-            except ImportError:
-                dummy_cache = 'dummy://'
-            else:
-                dummy_cache = 'django.core.cache.backends.dummy.DummyCache'
-
             # DEFAULT_CACHE_ALIAS doesn't exist in Django<=1.2
             try:
                 from django.core.cache import DEFAULT_CACHE_ALIAS as default_cache_alias
             except ImportError:
                 default_cache_alias = 'default'
 
-            if settings.DEBUG:
-                value = dummy_cache
-            elif default_cache_alias in getattr(settings, 'CACHES', {}):
+            if default_cache_alias in getattr(settings, 'CACHES', {}):
                 value = default_cache_alias
             else:
-                value = getattr(settings, 'CACHE_BACKEND', None) or dummy_cache
+                raise ValueError("The default cache alias '%s' is not available in CACHES" % value)
 
         return value
 

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -19,7 +19,8 @@ class ImageKitConf(AppConf):
         if value is None:
             # DEFAULT_CACHE_ALIAS doesn't exist in Django<=1.2
             try:
-                from django.core.cache import DEFAULT_CACHE_ALIAS as default_cache_alias
+                from django.core.cache import DEFAULT_CACHE_ALIAS
+                default_cache_alias = DEFAULT_CACHE_ALIAS or 'default'
             except ImportError:
                 default_cache_alias = 'default'
 

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -23,10 +23,21 @@ class ImageKitConf(AppConf):
             except ImportError:
                 default_cache_alias = 'default'
 
-            if default_cache_alias in getattr(settings, 'CACHES', {}):
+            caches = getattr(settings, 'CACHES', None)
+            if caches is None:
+                # Support Django<=1.2 there is no default `CACHES` setting
+                try:
+                    from django.core.cache.backends.dummy import DummyCache
+                except ImportError:
+                    dummy_cache = 'dummy://'
+                else:
+                    dummy_cache = 'django.core.cache.backends.dummy.DummyCache'
+                return dummy_cache
+
+            if default_cache_alias in caches:
                 value = default_cache_alias
             else:
-                raise ValueError("The default cache alias '%s' is not available in CACHES" % value)
+                raise ValueError("The default cache alias '%s' is not available in CACHES" % default_cache_alias)
 
         return value
 

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -19,8 +19,7 @@ class ImageKitConf(AppConf):
         if value is None:
             # DEFAULT_CACHE_ALIAS doesn't exist in Django<=1.2
             try:
-                from django.core.cache import DEFAULT_CACHE_ALIAS
-                default_cache_alias = DEFAULT_CACHE_ALIAS or 'default'
+                from django.core.cache import DEFAULT_CACHE_ALIAS as default_cache_alias
             except ImportError:
                 default_cache_alias = 'default'
 

--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -151,6 +151,16 @@ def call_strategy_method(file, method_name):
         fn(file)
 
 
+def get_cache(backend, **kwargs):
+    try:
+        from django.core.cache import caches
+    except ImportError:
+        from django.core.cache import get_cache
+        return get_cache(backend, **kwargs)
+
+    return caches[backend]
+
+
 def sanitize_cache_key(key):
     if settings.IMAGEKIT_USE_MEMCACHED_SAFE_CACHE_KEY:
         # Memcached keys can't contain whitespace or control characters.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'beautifulsoup4==4.1.3',
         'nose>=1.3.6,<1.4',
         'nose-progressive==1.5.1',
-        'django-nose>=1.2,<=1.4',
+        'django-nose>=1.2,<1.5',
         'Pillow<3.0',
         'mock==1.0.1',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,13 @@ commands = python setup.py test
 basepython = python3.5
 deps =
     git+https://github.com/django/django.git@stable/1.9.x#egg=Django
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py34-django19]
 basepython = python3.4
 deps =
     git+https://github.com/django/django.git@stable/1.9.x#egg=Django
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py34-django18]
 basepython = python3.4
@@ -87,7 +87,7 @@ deps =
 basepython = python2.7
 deps =
     git+https://github.com/django/django.git@stable/1.9.x#egg=Django
-    django-nose==1.4
+    git+https://github.com/django-nose/django-nose@master#egg=django-nose
 
 [testenv:py27-django18]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py33-django18, py33-django17, py33-django16, py33-django15,
     py32-django18, py32-django17, py32-django16, py32-django15,
     py27-django19, py27-django18, py27-django17, py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
-    py26-django15, py26-django14, py26-django13, py26-django12
+    py26-django16, py26-django15, py26-django14, py26-django13, py26-django12
 
 [testenv]
 commands = python setup.py test
@@ -127,6 +127,11 @@ basepython = python2.7
 deps =
     Django>=1.2,<1.3
     django-nose==1.2
+
+[testenv:py26-django16]
+basepython = python2.6
+deps =
+    Django>=1.6,<1.7
 
 [testenv:py26-django15]
 basepython = python2.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,26 @@
 [tox]
 envlist =
-    py34-django18, py34-django17, py34-django16,
+    py35-django19,
+    py34-django19, py34-django18, py34-django17, py34-django16,
     py33-django18, py33-django17, py33-django16, py33-django15,
     py32-django18, py32-django17, py32-django16, py32-django15,
-    py27-django18, py27-django17, py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
+    py27-django19, py27-django18, py27-django17, py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
     py26-django15, py26-django14, py26-django13, py26-django12
 
 [testenv]
 commands = python setup.py test
+
+[testenv:py35-django19]
+basepython = python3.5
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    django-nose==1.4
+
+[testenv:py34-django19]
+basepython = python3.4
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    django-nose==1.4
 
 [testenv:py34-django18]
 basepython = python3.4
@@ -69,6 +82,12 @@ deps =
 basepython = python3.2
 deps =
     Django>=1.5,<1.6
+
+[testenv:py27-django19]
+basepython = python2.7
+deps =
+    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    django-nose==1.4
 
 [testenv:py27-django18]
 basepython = python2.7


### PR DESCRIPTION
As discussed in the #321, we can probably just use the `caches` and not django private method.

This pull request can be opened to bring Django 1.9 compatibility, as we highly need it I am ready to fix warnings and issues nearly daily basis.

Cheers