### PR TITLE
Fix test requirements for django 1.9 and Python3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     tests_require=[
-        'beautifulsoup4==4.1.3',
-        'nose>=1.3.6,<1.4',
+        'beautifulsoup4==4.4.0',
+        'nose>=1.3.6,<1.5',
         'nose-progressive==1.5.1',
         'django-nose>=1.2,<1.5',
         'Pillow<3.0',

--- a/tox.ini
+++ b/tox.ini
@@ -13,20 +13,20 @@ commands = python setup.py test
 [testenv:py35-django19]
 basepython = python3.5
 deps =
-    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    Django>=1.9,<1.10
     django-nose==1.4.2
 
 [testenv:py34-django19]
 basepython = python3.4
 deps =
-    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
+    Django>=1.9,<1.10
     django-nose==1.4.2
 
 [testenv:py34-django18]
 basepython = python3.4
 deps =
     Django>=1.8,<1.9
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py34-django17]
 basepython = python3.4
@@ -43,7 +43,7 @@ deps =
 basepython = python3.3
 deps =
     Django>=1.8,<1.9
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py33-django17]
 basepython = python3.3
@@ -65,7 +65,7 @@ deps =
 basepython = python3.4
 deps =
     Django>=1.8,<1.9
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py32-django17]
 basepython = python3.4
@@ -86,14 +86,14 @@ deps =
 [testenv:py27-django19]
 basepython = python2.7
 deps =
-    git+https://github.com/django/django.git@stable/1.9.x#egg=Django
-    git+https://github.com/django-nose/django-nose@master#egg=django-nose
+    Django>=1.9,<1.10
+    django-nose==1.4.2
 
 [testenv:py27-django18]
 basepython = python2.7
 deps =
     Django>=1.8,<1.9
-    django-nose==1.4
+    django-nose==1.4.2
 
 [testenv:py27-django17]
 basepython = python2.7


### PR DESCRIPTION
 - Use `Django` and `nose` packages from PyPi
 - Update `BeautifulSoup4` to work with Python 3.5