### PR TITLE
Include the test suite in the sourcetarball but do not install it.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,17 @@
 include AUTHORS
 include LICENSE
 include README.rst
-recursive-include docs *
-recursive-include imagekit/templates *
-prune tests
+include testrunner.py
+include tests/*.py
+include tests/assets/Lenna.png
+include tests/assets/lenna-*.jpg
+include tests/media/lenna.png
+prune tests/media/CACHE
+prune tests/media/b
+prune tests/media/photos
+include docs/Makefile
+include docs/conf.py
+include docs/make.bat
+include docs/*.rst
+recursive-include docs/_themes LICENSE README.rst flask_theme_support.py theme.conf *.css_t *.css *.html
+recursive-include imagekit/templates *.html

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     maintainer_email='bryan@revyver.com',
     license='BSD',
     url='http://github.com/matthewwithanm/django-imagekit/',
-    packages=find_packages(),
+    packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
     zip_safe=False,
     include_package_data=True,
     tests_require=[


### PR DESCRIPTION
I reworked the `MANIFEST.in` to include the whole test suite so it can be used
by distribution packages during build time. It is excluded from the installed
packages automatically.

The inclusion rules for the documentation were also made more verbose to prevent
build artifacts from entering the source tarball (think .pyc files).