### PR TITLE
Drop support for older Django and Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ python: "2.7"
 sudo: false
 
 env:
-  - TOX_ENV=py26-django12
-  - TOX_ENV=py26-django13
-  - TOX_ENV=py26-django14
-  - TOX_ENV=py26-django15
-  - TOX_ENV=py26-django16
   - TOX_ENV=py27-django12
   - TOX_ENV=py27-django13
   - TOX_ENV=py27-django14
@@ -16,10 +11,6 @@ env:
   - TOX_ENV=py27-django17
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django19
-  - TOX_ENV=py32-django15
-  - TOX_ENV=py32-django16
-  - TOX_ENV=py32-django17
-  - TOX_ENV=py32-django18
   - TOX_ENV=py33-django15
   - TOX_ENV=py33-django16
   - TOX_ENV=py33-django17
@@ -28,13 +19,16 @@ env:
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
+  - TOX_ENV=py35-django18
   - TOX_ENV=py35-django19
 
 matrix:
-  # Python 3.5 not yet available on travis, watch this to see when it is.
   fast_finish: true
+  # Python 3.5 not yet available on travis, watch this to see when it is.
   allow_failures:
-    - env: TOX_ENV=py35-django19
+    - env:
+      - TOX_ENV=py35-django18
+      - TOX_ENV=py35-django19
 
 install:
   - pip install tox --use-mirrors

--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,12 @@ setup(
     zip_safe=False,
     include_package_data=True,
     tests_require=[
-        'beautifulsoup4==4.4.0',
-        'nose>=1.3.6,<1.5',
-        'nose-progressive==1.5.1',
-        'django-nose>=1.2,<1.5',
-        'Pillow<3.0',
-        'mock==1.0.1',
+        'beautifulsoup4>=4.4.0',
+        'nose>=1.3.6',
+        'nose-progressive>=1.5.1',
+        'django-nose>=1.4',
+        'Pillow',
+        'mock>=1.0.1',
     ],
     test_suite='testrunner.run_tests',
     install_requires=[
@@ -68,12 +68,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Utilities'
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
-    py35-django19,
+    py35-django19, py35-django18,
     py34-django19, py34-django18, py34-django17, py34-django16,
     py33-django18, py33-django17, py33-django16, py33-django15,
-    py32-django18, py32-django17, py32-django16, py32-django15,
-    py27-django19, py27-django18, py27-django17, py27-django16, py27-django15, py27-django14, py27-django13, py27-django12,
-    py26-django16, py26-django15, py26-django14, py26-django13, py26-django12
+    py27-django19, py27-django18, py27-django17, py27-django16, py27-django15, py27-django14,
 
 [testenv]
 commands = python setup.py test
@@ -14,6 +12,12 @@ commands = python setup.py test
 basepython = python3.5
 deps =
     Django>=1.9,<1.10
+    django-nose==1.4.2
+
+[testenv:py35-django18]
+basepython = python3.5
+deps =
+    Django>=1.8,<1.9
     django-nose==1.4.2
 
 [testenv:py34-django19]
@@ -61,28 +65,6 @@ basepython = python3.3
 deps =
     Django>=1.5,<1.6
 
-[testenv:py32-django18]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.9
-    django-nose==1.4.2
-
-[testenv:py32-django17]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.8
-    django-nose==1.4
-
-[testenv:py32-django16]
-basepython = python3.2
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py32-django15]
-basepython = python3.2
-deps =
-    Django>=1.5,<1.6
-
 [testenv:py27-django19]
 basepython = python2.7
 deps =
@@ -115,42 +97,3 @@ deps =
 basepython = python2.7
 deps =
     Django>=1.4,<1.5
-
-[testenv:py27-django13]
-basepython = python2.7
-deps =
-    Django>=1.3,<1.4
-    django-nose==1.2
-
-[testenv:py27-django12]
-basepython = python2.7
-deps =
-    Django>=1.2,<1.3
-    django-nose==1.2
-
-[testenv:py26-django16]
-basepython = python2.6
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py26-django15]
-basepython = python2.6
-deps =
-    Django>=1.5,<1.6
-
-[testenv:py26-django14]
-basepython = python2.6
-deps =
-    Django>=1.4,<1.5
-
-[testenv:py26-django13]
-basepython = python2.6
-deps =
-    Django>=1.3,<1.4
-    django-nose==1.2
-
-[testenv:py26-django12]
-basepython = python2.6
-deps =
-    Django>=1.2,<1.3
-    django-nose==1.2


### PR DESCRIPTION
This change drop official support for Django 1.2 and 1.3 and Python 2.6 and 3.2

In this commit test requirements are not so strict to allow versions available in Debian sid.

Fixes #362

Many thanks to @fladi