### PR TITLE
Fixed #350: Error when trying to access width/height after url

### DIFF
--- a/imagekit/files.py
+++ b/imagekit/files.py
@@ -56,7 +56,18 @@ class BaseIKFile(File):
 
     def open(self, mode='rb'):
         self._require_file()
-        self.file.open(mode)
+        try:
+            self.file.open(mode)
+        except ValueError:
+            # if the underlaying file can't be reopened
+            # then we will use the storage to try to open it again
+            if self.file.closed:
+                # clear cached file instance
+                del self.file
+                # Because file is a property we can acces it after
+                # we deleted it
+                return self.file.open(mode)
+            raise
 
     def _get_closed(self):
         file = getattr(self, '_file', None)

--- a/tests/test_generateimage_tag.py
+++ b/tests/test_generateimage_tag.py
@@ -50,7 +50,7 @@ def test_single_dimension_attr():
 
 
 def test_assignment_tag():
-    ttag = r"""{% generateimage 'testspec' source=img as th %}{{ th.url }}"""
+    ttag = r"""{% generateimage 'testspec' source=img as th %}{{ th.url }}{{ th.height }}{{ th.width }}"""
     clear_imagekit_cache()
     html = render_tag(ttag)
     assert_not_equal(html.strip(), '')


### PR DESCRIPTION
If the file is closed and something is calling `open` now the file will be opened correctly event if it was already closed

Fixes #350