### PR TITLE
Add new attribute 'IMAGEKIT_CACHE_TIMEOUT'

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,6 +62,15 @@ Settings
     A cache prefix to be used when values are stored in ``IMAGEKIT_CACHE_BACKEND``
 
 
+.. attribute:: IMAGEKIT_CACHE_TIMEOUT
+
+    :default:  ``selected backend cache default timeout``
+
+    Use when you need to override the default timeout from the backend cache defined in
+    IMAGEKIT_CACHE_BACKEND attribute. It's highly recommended that you 
+    use a very high timeout.
+
+
 .. attribute:: IMAGEKIT_CACHEFILE_NAMER
 
     :default: ``'imagekit.cachefiles.namers.hash'``

--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -75,7 +75,7 @@ class CachedFileBackend(object):
             self.cache.set(key, state, self.existence_check_timeout)
         else:
             from django.conf import settings
-            if hasattr('IMAGEKIT_CACHE_TIMEOUT', settings):
+            if hasattr(settings, 'IMAGEKIT_CACHE_TIMEOUT'):
                 self.cache.set(key, state, settings.IMAGEKIT_CACHE_TIMEOUT)
             else:
                 self.cache.set(key, state)

--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -74,7 +74,11 @@ class CachedFileBackend(object):
         if state == CacheFileState.DOES_NOT_EXIST:
             self.cache.set(key, state, self.existence_check_timeout)
         else:
-            self.cache.set(key, state)
+            from django.conf import settings
+            if hasattr('IMAGEKIT_CACHE_TIMEOUT', settings):
+                self.cache.set(key, state, settings.IMAGEKIT_CACHE_TIMEOUT)
+            else:
+                self.cache.set(key, state)
 
     def __getstate__(self):
         state = copy(self.__dict__)


### PR DESCRIPTION
In some projects the default timeout from caches are not very high - by choice or by Django default (5 minutes). 

I believe this new attribute can give  more control on default timeout behavior for imagekit.

Thank you for the time evaluating this PR.