### PR TITLE
Improve caching

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -100,13 +100,21 @@ ImageKit. Each has its own pros and cons.
 Caching Data About Generated Files
 ----------------------------------
 
-The easiest, and most significant improvement you can make to improve the
-performance of your site is to have ImageKit cache the state of your generated
-files. The default cache file backend will already do this (if ``DEBUG`` is
-``False``), using your default Django cache backend, but you can make it way
-better by setting ``IMAGEKIT_CACHE_BACKEND``. Generally, once a file is
-generated, you will never be removing it; therefore, if you can, you should set
-``IMAGEKIT_CACHE_BACKEND`` to a cache backend that will cache forever.
+Generally, once a file is generated, you will never be removing it, so by
+default ImageKit will use default cache to cache the state of generated
+files "forever" (or only 5 minutes when ``DEBUG = True``).
+
+The time for which ImageKit will cache state is configured with
+``IMAGEKIT_CACHE_TIMEOUT``. If set to ``None`` this means "never expire"
+(default when ``DEBUG = False``). You can reduce this timeout if you want
+or set it to some numeric value in seconds if your cache backend behaves
+differently and for example do not cache values if timeout is ``None``.
+
+If you clear your cache durring deployment or some other reason probably
+you do not want to lose the cache for generated images especcialy if you
+are using some slow remote storage (like Amazon S3). Then you can configure
+seprate cache (for example redis) in your ``CACHES`` config and tell ImageKit
+to use it instead of the default cache by setting ``IMAGEKIT_CACHE_BACKEND``.
 
 
 Pre-Generating Images

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,6 +55,15 @@ Settings
 .. _`Django cache section`: https://docs.djangoproject.com/en/1.8/topics/cache/#accessing-the-cache
 
 
+.. attribute:: IMAGEKIT_CACHE_TIMEOUT
+
+    :default: ``None``
+
+    Use when you need to override the timeout used to cache file state.
+    By default it is "cache forever".
+    It's highly recommended that you use a very high timeout.
+
+
 .. attribute:: IMAGEKIT_CACHE_PREFIX
 
     :default: ``'imagekit:'``

--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -2,6 +2,7 @@ from ..utils import get_singleton, get_cache, sanitize_cache_key
 import warnings
 from copy import copy
 from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
 
 
 class CacheFileState(object):
@@ -74,7 +75,7 @@ class CachedFileBackend(object):
         if state == CacheFileState.DOES_NOT_EXIST:
             self.cache.set(key, state, self.existence_check_timeout)
         else:
-            self.cache.set(key, state)
+            self.cache.set(key, state, settings.IMAGEKIT_CACHE_TIMEOUT)
 
     def __getstate__(self):
         state = copy(self.__dict__)

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -1,5 +1,6 @@
 from appconf import AppConf
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 class ImageKitConf(AppConf):
@@ -17,27 +18,11 @@ class ImageKitConf(AppConf):
 
     def configure_cache_backend(self, value):
         if value is None:
-            # DEFAULT_CACHE_ALIAS doesn't exist in Django<=1.2
-            try:
-                from django.core.cache import DEFAULT_CACHE_ALIAS as default_cache_alias
-            except ImportError:
-                default_cache_alias = 'default'
+            from django.core.cache import DEFAULT_CACHE_ALIAS
+            return DEFAULT_CACHE_ALIAS
 
-            caches = getattr(settings, 'CACHES', None)
-            if caches is None:
-                # Support Django<=1.2 there is no default `CACHES` setting
-                try:
-                    from django.core.cache.backends.dummy import DummyCache
-                except ImportError:
-                    dummy_cache = 'dummy://'
-                else:
-                    dummy_cache = 'django.core.cache.backends.dummy.DummyCache'
-                return dummy_cache
-
-            if default_cache_alias in caches:
-                value = default_cache_alias
-            else:
-                raise ValueError("The default cache alias '%s' is not available in CACHES" % default_cache_alias)
+        if value not in settings.CACHES:
+            raise ImproperlyConfigured("{0} is not present in settings.CACHES".format(value))
 
         return value
 

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -14,6 +14,7 @@ class ImageKitConf(AppConf):
 
     CACHE_BACKEND = None
     CACHE_PREFIX = 'imagekit:'
+    CACHE_TIMEOUT = None
     USE_MEMCACHED_SAFE_CACHE_KEY = True
 
     def configure_cache_backend(self, value):
@@ -24,6 +25,13 @@ class ImageKitConf(AppConf):
         if value not in settings.CACHES:
             raise ImproperlyConfigured("{0} is not present in settings.CACHES".format(value))
 
+        return value
+
+    def configure_cache_timeout(self, value):
+        if value is None and settings.DEBUG:
+            # If value is not configured and is DEBUG set it to 5 minutes
+            return 300
+        # Otherwise leave it as is. If it is None then valies will never expire
         return value
 
     def configure_default_file_storage(self, value):

--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -148,14 +148,15 @@ def call_strategy_method(file, method_name):
         fn(file)
 
 
-def get_cache(backend=settings.IMAGEKIT_CACHE_BACKEND):
+def get_cache():
     try:
         from django.core.cache import caches
     except ImportError:
+        # Django < 1.7
         from django.core.cache import get_cache
-        return get_cache(backend)
+        return get_cache(settings.IMAGEKIT_CACHE_BACKEND)
 
-    return caches[backend]
+    return caches[settings.IMAGEKIT_CACHE_BACKEND]
 
 
 def sanitize_cache_key(key):


### PR DESCRIPTION
- ~~Use 1 day cache~~ Cache "forever" by default when in production `DEBUG = False` 
- Make it possible to configure cache timeout ~~to large values~~ by setting `IMAGEKIT_CACHE_TIMEOUT`

Fixed #399 #402