### PR TITLE
Ignore autogenerated CTags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 /venv
 /venv3
 /.env
+/tags


### PR DESCRIPTION
This file is used by some IDEs to index all Symbols in the project