### PR TITLE
Performance improvement

### DIFF
--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -79,6 +79,7 @@ def autodiscover():
         _autodiscover_modules_fallback()
     else:
         autodiscover_modules('imagegenerators')
+        _autodiscovered = True
 
 
 def _autodiscover_modules_fallback():

--- a/imagekit/utils.py
+++ b/imagekit/utils.py
@@ -79,7 +79,7 @@ def autodiscover():
         _autodiscover_modules_fallback()
     else:
         autodiscover_modules('imagegenerators')
-        _autodiscovered = True
+    _autodiscovered = True
 
 
 def _autodiscover_modules_fallback():
@@ -92,19 +92,12 @@ def _autodiscover_modules_fallback():
 
     Used for Django versions < 1.7
     """
-    global _autodiscovered
-
-    if _autodiscovered:
-        return
-
     from django.conf import settings
     try:
         from importlib import import_module
     except ImportError:
         from django.utils.importlib import import_module
     from django.utils.module_loading import module_has_submodule
-
-    _autodiscovered = True
 
     for app in settings.INSTALLED_APPS:
         # As of Django 1.7, settings.INSTALLED_APPS may contain classes instead of modules, hence the try/except


### PR DESCRIPTION
After pouring over the imagekit code I believe I have found the culprit that causes the major performance problems voiced in: https://github.com/matthewwithanm/django-imagekit/issues/325, https://github.com/matthewwithanm/django-imagekit/issues/375, https://github.com/matthewwithanm/django-imagekit/issues/256, https://github.com/matthewwithanm/django-imagekit/issues/250
Starting with Django >= 1.7 every call to retrieve a generator would erroneously run the imagekit.utils.autodiscover routine.  This fix allows the routine to be run only once.