### PR TITLE
Improve docs for Python 3 - files should be opened as binary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ on, or what should be done with the result; that's up to you:
 
 .. code-block:: python
 
-    source_file = open('/path/to/myimage.jpg')
+    source_file = open('/path/to/myimage.jpg', 'rb')
     image_generator = Thumbnail(source=source_file)
     result = image_generator.generate()
 
@@ -159,7 +159,7 @@ example, if you wanted to save it to disk:
 
 .. code-block:: python
 
-    dest = open('/path/to/dest.jpg', 'w')
+    dest = open('/path/to/dest.jpg', 'wb')
     dest.write(result.read())
     dest.close()
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -163,7 +163,7 @@ A simple example of a custom source group class is as follows:
         def files(self):
             os.chdir(self.dir)
             for name in glob.glob('*.jpg'):
-                yield open(name)
+                yield open(name, 'rb')
 
 Instances of this class could then be registered with one or more spec id:
 


### PR DESCRIPTION
Related to #420 #418 