### PR TITLE
Fix `ImageCacheFile.__repr__` to not send signals

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.images import ImageFile
 from django.utils.functional import SimpleLazyObject
+from django.utils.encoding import smart_str
 from ..files import BaseIKFile
 from ..registry import generator_registry
 from ..signals import content_required, existence_required
@@ -148,6 +149,11 @@ class ImageCacheFile(BaseIKFile, ImageFile):
     def __nonzero__(self):
         # Python 2 compatibility
         return self.__bool__()
+
+    def __repr__(self):
+        return smart_str("<%s: %s>" % (
+            self.__class__.__name__, self if self.name else "None")
+        )
 
 
 class LazyImageCacheFile(SimpleLazyObject):


### PR DESCRIPTION
Cachefile strategy may be configured to generate file when file existance required.

To generate images, async backends passes `ImageCacheFile` instance to a worker.
Both celery and RQ calls `__repr__` method for each argument to the enque call.
And if `__repr__` of the object will send `existnace_required` signal, we will get endless recursion.

Issue: #434