### PR TITLE
Fix image cachefile serializtion

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -185,6 +185,11 @@ Or, in Python:
             def on_source_saved(self, file):
                 file.generate()
 
+.. note::
+
+    If you use custom storage backend for some specs,
+    (storage passed to the field different than configured one)
+    it's required the storage to be pickleable
 
 
 __ https://pypi.python.org/pypi/django-celery

--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -144,7 +144,23 @@ class ImageCacheFile(BaseIKFile, ImageFile):
         # file is hidden link to "file" attribute
         state.pop('_file', None)
 
+        # remove storage from state as some non-FileSystemStorage can't be
+        # pickled
+        settings_storage = get_singleton(
+            settings.IMAGEKIT_DEFAULT_FILE_STORAGE,
+            'file storage backend'
+        )
+        if state['storage'] == settings_storage:
+            state.pop('storage')
         return state
+
+    def __setstate__(self, state):
+        if 'storage' not in state:
+            state['storage'] = get_singleton(
+                settings.IMAGEKIT_DEFAULT_FILE_STORAGE,
+                'file storage backend'
+            )
+        self.__dict__.update(state)
 
     def __nonzero__(self):
         # Python 2 compatibility


### PR DESCRIPTION
Fix pickle serialization for ImageCacheFile

When `Celery` CachedFileBackend used with filesystem storage (`django.core.files.storage.FileSystemStorage`), everything works fine.
But there are issues with `storages.backends.s3boto3.S3Boto3Storage` (and it's fix from #391), as well as with `django_s3_storage.storage.S3Storage`.

I didn't debug it to the real core reason, but seem like `pickle` serializer used for celery task can't serialize `ImageCacheFile.storage`. So passing instance of
`ImageCacheFile` was replaced with passing its generator without storage attrs, which serializes without any errors

It seems like a hacky solution, but it works

Exception was:
```
Traceback (most recent call last):
  ...

  File "/src/django-imagekit/imagekit/cachefiles/__init__.py", line 131, in __bool__
    existence_required.send(sender=self, file=self)
  ...
  File "/libs/utils.py", line 380, in on_existence_required
    file.generate()
  File "/src/django-imagekit/imagekit/cachefiles/__init__.py", line 94, in generate
    self.cachefile_backend.generate(self, force)
  File "/src/django-imagekit/imagekit/cachefiles/backends.py", line 136, in generate
    self.schedule_generation(file, force=force)
  File "/src/django-imagekit/imagekit/cachefiles/backends.py", line 165, in schedule_generation
    _celery_task.delay(self, file.generator, force=force)
  ...
  File "/lib/python3.6/site-packages/kombu/serialization.py", line 221, in dumps
    payload = encoder(data)
  File "/lib/python3.6/site-packages/kombu/serialization.py", line 350, in pickle_dumps
    return dumper(obj, protocol=pickle_protocol)
kombu.exceptions.EncodeError: can't pickle _thread._local objects
```