### PR TITLE
Python 3.6 and Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,66 +1,46 @@
+sudo: false
 
 language: python
-
-sudo: false
+python:
+  - "3.6"
+  - "3.5"
+env:
+  - DJANGO="master"
+  - DJANGO="21"
+  - DJANGO="20"
+  - DJANGO="111"
 
 install:
   - pip install tox
 
 script:
-  - tox
+  - tox -e py$(python -c 'import sys;print("".join(map(str, sys.version_info[:2])))')-django${DJANGO}
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: DJANGO="master"
   include:
-    - env: TOXENV=py27-django14
-      python: 2.7
-    - env: TOXENV=py27-django15
-      python: 2.7
-    - env: TOXENV=py27-django16
-      python: 2.7
-    - env: TOXENV=py27-django17
-      python: 2.7
-    - env: TOXENV=py27-django18
-      python: 2.7
-    - env: TOXENV=py27-django19
-      python: 2.7
-    - env: TOXENV=py27-django110
-      python: 2.7
-    - env: TOXENV=py27-django111
-      python: 2.7
-    - env: TOXENV=py33-django15
-      python: 3.3
-    - env: TOXENV=py33-django16
-      python: 3.3
-    - env: TOXENV=py33-django17
-      python: 3.3
-    - env: TOXENV=py33-django18
-      python: 3.3
-    - env: TOXENV=py34-django16
-      python: 3.4
-    - env: TOXENV=py34-django17
-      python: 3.4
-    - env: TOXENV=py34-django18
-      python: 3.4
-    - env: TOXENV=py34-django19
-      python: 3.4
-    - env: TOXENV=py34-django110
-      python: 3.4
-    - env: TOXENV=py34-django111
-      python: 3.4
-    - env: TOXENV=py34-django20
-      python: 3.4
-    - env: TOXENV=py35-django18
-      python: 3.5
-    - env: TOXENV=py35-django19
-      python: 3.5
-    - env: TOXENV=py35-django110
-      python: 3.5
-    - env: TOXENV=py35-django111
-      python: 3.5
-    - env: TOXENV=py35-django20
-      python: 3.5
+    - python: "3.5"
+      env: DJANGO="18"
 
+    - python: "3.4"
+      env: DJANGO="20"
+    - python: "3.4"
+      env: DJANGO="111"
+    - python: "3.4"
+      env: DJANGO="18"
+    - python: "3.4"
+      env: DJANGO="16"
+    
+    - python: "2.7"
+      env: DJANGO="111"
+    - python: "2.7"
+      env: DJANGO="18"
+    - python: "2.7"
+      env: DJANGO="16"
+    - python: "2.7"
+      env: DJANGO="14"
 
 notifications:
   irc: "irc.freenode.org#imagekit"

--- a/tox.ini
+++ b/tox.ini
@@ -1,153 +1,26 @@
 [tox]
 envlist =
-    py35-django20, py35-django111, py35-django110, py35-django19, py35-django18,
-    py34-django20, py34-django111, py34-django110, py34-django19, py34-django18, py34-django17, py34-django16,
-    py33-django18, py33-django17, py33-django16, py33-django15,
-    py27-django111, py27-django110, py27-django19, py27-django18, py27-django17, py27-django16, py27-django15, py27-django14,
+    py36-django{master,21,20,111},
+    py35-django{master,21,20,111,18},
+    py34-django{21,20,111,18,16},
+    py27-django{111,18,16,14}
 
 [testenv]
 commands = python setup.py test
 
-[testenv:py35-django20]
-basepython = python3.5
 deps =
-    Django>=2.0,<2.1
-    django-nose==1.4.5
-
-[testenv:py35-django111]
-basepython = python3.5
-deps =
-    Django>=1.11,<1.12
-    django-nose==1.4.5
-
-[testenv:py35-django110]
-basepython = python3.5
-deps =
-    Django>=1.10,<1.11
-    django-nose==1.4.4
-
-[testenv:py35-django19]
-basepython = python3.5
-deps =
-    Django>=1.9,<1.10
-    django-nose==1.4.2
-
-[testenv:py35-django18]
-basepython = python3.5
-deps =
-    Django>=1.8,<1.9
-    django-nose==1.4.2
-
-[testenv:py34-django20]
-basepython = python3.4
-deps =
-    Django>=2.0,<2.1
-    django-nose==1.4.5
-
-[testenv:py34-django111]
-basepython = python3.4
-deps =
-    Django>=1.11,<1.12
-    django-nose==1.4.5
-
-[testenv:py34-django110]
-basepython = python3.4
-deps =
-    Django>=1.10,<1.11
-    django-nose==1.4.4
-
-[testenv:py34-django19]
-basepython = python3.4
-deps =
-    Django>=1.9,<1.10
-    django-nose==1.4.2
-
-[testenv:py34-django18]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.9
-    django-nose==1.4.2
-
-[testenv:py34-django17]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.8
-    django-nose==1.4
-
-[testenv:py34-django16]
-basepython = python3.4
-deps =
-    Django>=1.6,<1.7
-    django-nose<=1.4.2
-
-[testenv:py33-django18]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.9
-    django-nose==1.4.2
-
-[testenv:py33-django17]
-basepython = python3.3
-deps =
-    Django>=1.7,<1.8
-    django-nose==1.4
-
-[testenv:py33-django16]
-basepython = python3.3
-deps =
-    Django>=1.6,<1.7
-    django-nose<=1.4.2
-
-[testenv:py33-django15]
-basepython = python3.3
-deps =
-    Django>=1.5,<1.6
-    django-nose==1.4
-
-[testenv:py27-django111]
-basepython = python2.7
-deps =
-    Django>=1.11,<1.12
-    django-nose==1.4.5
-
-[testenv:py27-django110]
-basepython = python2.7
-deps =
-    Django>=1.10,<1.11
-    django-nose==1.4.4
-
-[testenv:py27-django19]
-basepython = python2.7
-deps =
-    Django>=1.9,<1.10
-    django-nose==1.4.2
-
-[testenv:py27-django18]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.9
-    django-nose==1.4.2
-
-[testenv:py27-django17]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.8
-    django-nose==1.4
-
-[testenv:py27-django16]
-basepython = python2.7
-deps =
-    Django>=1.6,<1.7
-    django-nose<=1.4.2
-
-[testenv:py27-django15]
-basepython = python2.7
-deps =
-    Django>=1.5,<1.6
-    django-nose==1.4
-
-[testenv:py27-django14]
-basepython = python2.7
-deps =
-    Django>=1.4,<1.5
-    django-nose==1.4
+    djangomaster: git+https://github.com/django/django.git@master#egg=Django
+    django21: Django>=2.1,<2.2
+    django20: Django>=2.0,<2.1
+    django111: Django>=1.11,<2.0
+    django110: Django>=1.10,<1.11
+    django19: Django>=1.9,<1.10
+    django18: Django>=1.8,<1.9
+    django17: Django>=1.7,<1.8
+    django16: Django>=1.6,<1.7
+    django15: Django>=1.5,<1.6
+    django14: Django>=1.4,<1.5
+    django{21,20,111}: django-nose==1.4.5
+    django110: django-nose==1.4.4
+    django{19,18,17,16}: django-nose==1.4.2
+    django{15,14}: django-nose==1.4


### PR DESCRIPTION
- Stop testing some configurations of older Django versions.
- Test aginast Django master
- Simplify tox configuration to reduce number of lines.
- Simplify travis configuration to reduce number of lines.