### PR TITLE
ValueError on content.seek(0)

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -100,7 +100,11 @@ class ImageCacheFile(BaseIKFile, ImageFile):
         actual_name = self.storage.save(self.name, content)
 
         # We're going to reuse the generated file, so we need to reset the pointer.
-        content.seek(0)
+        try:
+            content.seek(0)
+        except ValueError as e:
+            # I get I/O operation on closed file. Ignoring it works.
+            pass
 
         # Store the generated file. If we don't do this, the next time the
         # "file" attribute is accessed, it will result in a call to the storage


### PR DESCRIPTION
When storing media files in s3 content.seek(0) raises 'ValueError: I/O operation on closed file.' - ignoring it just works.