### PR TITLE
fix broken links in documentation (#319)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ Installation
 Usage Overview
 ==============
 
+.. _specs:
 
 Specs
 -----

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -3,7 +3,7 @@ Caching
 
 
 Default Backend Workflow
-================
+========================
 
 
 ``ImageSpec``
@@ -28,6 +28,8 @@ wraps an image generator. They look and feel just like regular file
 objects, but they've got a little trick up their sleeve: they represent files
 that may not actually exist!
 
+
+.. _cache-file-strategy:
 
 Cache File Strategy
 -------------------
@@ -54,6 +56,8 @@ The default strategy only defines the first two of these, as follows:
         def on_existence_required(self, file):
             file.generate()
 
+
+.. _cache-file-backend:
 
 Cache File Backend
 ------------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -79,11 +79,8 @@ IK3 provides analogous settings for cache file backends and strategies:
     IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = 'path.to.MyCacheFileBackend'
     IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = 'path.to.MyCacheFileStrategy'
 
-See the documentation on `cache file backends`_ and `cache file strategies`_
+See the documentation on :ref:`cache file backends <cache-file-backend>` and :ref:`cache file strategies <cache-file-strategy>`
 for more details.
-
-.. _`cache file backends`:
-.. _`cache file strategies`:
 
 
 Conditional model ``processors``
@@ -93,9 +90,7 @@ In IK2, an ``ImageSpecField`` could take a ``processors`` callable instead of
 an iterable, which allowed processing decisions to made based on other
 properties of the model. IK3 does away with this feature for consistency's sake
 (if one kwarg could be callable, why not all?), but provides a much more robust
-solution: the custom ``spec``. See the `advanced usage`_ documentation for more.
-
-.. _`advanced usage`:
+solution: the custom ``spec``. See the :doc:`advanced usage <advanced_usage>` documentation for more.
 
 
 Conditonal ``cache_to`` file names
@@ -109,9 +104,7 @@ There is a way to achieve custom file names by overriding your spec's
 ``cachefile_name``, but it is not recommended, as the spec's default
 behavior is to hash the combination of ``source``, ``processors``, ``format``,
 and other spec options to ensure that changes to the spec always result in
-unique file names. See the documentation on `specs`_ for more.
-
-.. _`specs`:
+unique file names. See the documentation on :ref:`specs` for more.
 
 
 Processors have moved to PILKit


### PR DESCRIPTION
This commit fixes #319  by adding a few labels and pointing the links in the Upgrading section to the relevant sections elsewhere in the docs.