### PR TITLE
docs: Fix simple typo, assigment -> assignment

### DIFF
--- a/tests/test_generateimage_tag.py
+++ b/tests/test_generateimage_tag.py
@@ -30,7 +30,7 @@ def test_dangling_html_attrs_delimiter():
 @raises(TemplateSyntaxError)
 def test_html_attrs_assignment():
     """
-    You can either use generateimage as an assigment tag or specify html attrs,
+    You can either use generateimage as an assignment tag or specify html attrs,
     but not both.
 
     """

--- a/tests/test_thumbnail_tag.py
+++ b/tests/test_thumbnail_tag.py
@@ -42,7 +42,7 @@ def test_too_many_args():
 @raises(TemplateSyntaxError)
 def test_html_attrs_assignment():
     """
-    You can either use thumbnail as an assigment tag or specify html attrs,
+    You can either use thumbnail as an assignment tag or specify html attrs,
     but not both.
 
     """


### PR DESCRIPTION
There is a small typo in tests/test_generateimage_tag.py, tests/test_thumbnail_tag.py.

Should read `assignment` rather than `assigment`.

