### PR TITLE
Update tests and build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@ sudo: false
 
 language: python
 python:
+  - "3.8"
+  - "3.7"
   - "3.6"
   - "3.5"
 env:
   - DJANGO="master"
+  - DJANGO="30"
+  - DJANGO="22"
+  - DJANGO="21"
   - DJANGO="21"
   - DJANGO="20"
   - DJANGO="111"
@@ -16,31 +21,15 @@ install:
 script:
   - tox -e py$(python -c 'import sys;print("".join(map(str, sys.version_info[:2])))')-django${DJANGO}
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - env: DJANGO="master"
-  include:
+  exclude:
     - python: "3.5"
-      env: DJANGO="18"
-
-    - python: "3.4"
-      env: DJANGO="20"
-    - python: "3.4"
-      env: DJANGO="111"
-    - python: "3.4"
-      env: DJANGO="18"
-    - python: "3.4"
-      env: DJANGO="16"
-    
-    - python: "2.7"
-      env: DJANGO="111"
-    - python: "2.7"
-      env: DJANGO="18"
-    - python: "2.7"
-      env: DJANGO="16"
-    - python: "2.7"
-      env: DJANGO="14"
+      env: DJANGO="30"
+    - python: "3.5"
+      env: DJANGO="master"
 
 notifications:
   irc: "irc.freenode.org#imagekit"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ execfile(os.path.join(os.path.dirname(__file__), '..', 'imagekit',
 # built documents.
 #
 # The short X.Y version.
-version = re.match('\d+\.\d+', pkgmeta['__version__']).group()
+version = re.match(r'\d+\.\d+', pkgmeta['__version__']).group()
 # The full version, including alpha/beta/rc tags.
 release = pkgmeta['__version__']
 

--- a/tests/test_cachefiles.py
+++ b/tests/test_cachefiles.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.conf import settings
 from hashlib import md5
 from imagekit.cachefiles import ImageCacheFile, LazyImageCacheFile

--- a/tests/test_no_extra_queries.py
+++ b/tests/test_no_extra_queries.py
@@ -1,5 +1,5 @@
 from nose.tools import assert_false
-from mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 from .models import Photo
 
 

--- a/tests/test_optimistic_strategy.py
+++ b/tests/test_optimistic_strategy.py
@@ -1,6 +1,6 @@
 from nose.tools import assert_true, assert_false
 from imagekit.cachefiles import ImageCacheFile
-from mock import Mock
+from unittest.mock import Mock
 from .utils import create_image
 from django.core.files.storage import FileSystemStorage
 from imagekit.cachefiles.backends import Simple as SimpleCFBackend

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,18 @@
 [tox]
 envlist =
-    py36-django{master,21,20,111},
-    py35-django{master,21,20,111,18},
-    py34-django{21,20,111,18,16},
-    py27-django{111,18,16,14}
+    py38-django{master,30,22,21,20,111},
+    py37-django{master,30,22,21,20,111},
+    py36-django{master,30,22,21,20,111},
+    py35-django{21,20,111},
 
 [testenv]
 commands = python setup.py test
 
 deps =
     djangomaster: git+https://github.com/django/django.git@master#egg=Django
+    django30: Django>=3.0,<3.1
+    django22: Django>=2.2,<3.0
     django21: Django>=2.1,<2.2
     django20: Django>=2.0,<2.1
     django111: Django>=1.11,<2.0
-    django110: Django>=1.10,<1.11
-    django19: Django>=1.9,<1.10
-    django18: Django>=1.8,<1.9
-    django17: Django>=1.7,<1.8
-    django16: Django>=1.6,<1.7
-    django15: Django>=1.5,<1.6
-    django14: Django>=1.4,<1.5
     django{21,20,111}: django-nose==1.4.5
-    django110: django-nose==1.4.4
-    django{19,18,17,16}: django-nose==1.4.2
-    django{15,14}: django-nose==1.4


### PR DESCRIPTION
Updated tests to work under python3, updated travis.yml matrix.

- Update test to work with Python3
- Use mock classes from Python unittest package
- Remove old unmaintained Python and Django versions from tests.