### PR TITLE
Use gettext_lazy in Django 2.0+ (ugettext_lazy is deprecated)

### DIFF
--- a/imagekit/admin.py
+++ b/imagekit/admin.py
@@ -1,4 +1,10 @@
-from django.utils.translation import ugettext_lazy as _
+from django import VERSION
+if VERSION[0] < 2:
+    # ugettext is an alias for gettext() since Django 2.0,
+    # and deprecated as of Django 3.0.
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 
 


### PR DESCRIPTION
`ugettext()` is an alias for `gettext()` since Django 2.0 and is deprecated as of Django 3.0.

Avoid deprecation warning:

> RemovedInDjango40Warning: django.utils.translation.ugettext_lazy()
> is deprecated in favor of django.utils.translation.gettext_lazy()

Ref:

- https://docs.djangoproject.com/en/3.1/releases/3.0/#features-deprecated-in-3-0
- https://github.com/django/django/blob/2b443cb6c2d55669b20019f2755c0711c3d23050/django/utils/translation/__init__.py#L139