### PR TITLE
#473 fix for 'seek of closed file' Error

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -97,16 +97,15 @@ class ImageCacheFile(BaseIKFile, ImageFile):
         # Generate the file
         content = generate(self.generator)
 
-        actual_name = self.storage.save(self.name, content)
-
-        # We're going to reuse the generated file, so we need to reset the pointer.
-        content.seek(0)
-
         # Store the generated file. If we don't do this, the next time the
         # "file" attribute is accessed, it will result in a call to the storage
         # backend (in ``BaseIKFile._get_file``). Since we already have the
         # contents of the file, what would the point of that be?
         self.file = File(content)
+
+        # We're going to reuse the generated file, so we need to reset the pointer.
+        content.seek(0)
+        actual_name = self.storage.save(self.name, content)
 
         if actual_name != self.name:
             get_logger().warning(


### PR DESCRIPTION
need to change the order here, first populate "self.file", then seek to start of file handle, and then "self.storage.save" (which will result in a closed file handle, from which we can no longer seek nor read)