### PR TITLE
Add Dramatiq-based async cache file backend

### DIFF
--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -193,3 +193,27 @@ class RQ(BaseAsync):
 
     def schedule_generation(self, file, force=False):
         _rq_job.delay(self, file, force=force)
+
+
+try:
+    from dramatiq import actor
+except ImportError:
+    pass
+else:
+    _dramatiq_actor = actor()(_generate_file)
+
+
+class Dramatiq(BaseAsync):
+    """
+    A backend that uses Dramatiq to generate the images.
+    """
+    def __init__(self, *args, **kwargs):
+        try:
+            import dramatiq  # noqa
+        except ImportError:
+            raise ImproperlyConfigured('You must install django-dramatiq to use'
+                                        ' imagekit.cachefiles.backends.Dramatiq.')
+        super(Dramatiq, self).__init__(*args, **kwargs)
+
+    def schedule_generation(self, file, force=False):
+        _dramatiq_actor.send(self, file, force=force)


### PR DESCRIPTION
References:
- [dramatiq](dramatiq.io)
- [django-dramatiq](https://github.com/Bogdanp/django_dramatiq/)

To use pickle serializer, set `DRAMATIQ_ENCODER = "dramatiq.PickleEncoder"` in project settings