### PR TITLE
Import force/smart_str instead of force/smart_text

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/imagekit/lib.py
+++ b/imagekit/lib.py
@@ -40,7 +40,9 @@ except ImportError:
 # If Django version is under 1.5 then use `force_unicde`
 # It is used for compatibility between Python 2 and Python 3
 try:
-    from django.utils.encoding import force_text, force_bytes, smart_text
+    from django.utils.encoding import (force_str as force_text,
+                                       force_bytes,
+                                       smart_str as smart_text)
 except ImportError:
     # Django < 1.5
     from django.utils.encoding import (force_unicode as force_text,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'django-appconf>=0.5',
+        "django-appconf>=0.5,<1.0.4; python_version<'3'",
+        "django-appconf; python_version>'3'",
         'pilkit>=0.2.0',
         'six',
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 # Test requirements
+mock; python_version<'3'
 beautifulsoup4
 Pillow
 pytest

--- a/tests/test_cachefiles.py
+++ b/tests/test_cachefiles.py
@@ -1,6 +1,10 @@
 import pytest
 
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from django.conf import settings
 from hashlib import md5
 from imagekit.cachefiles import ImageCacheFile, LazyImageCacheFile

--- a/tests/test_no_extra_queries.py
+++ b/tests/test_no_extra_queries.py
@@ -1,4 +1,8 @@
-from unittest.mock import Mock, PropertyMock, patch
+try:
+    from unittest.mock import Mock, PropertyMock, patch
+except:
+    from mock import Mock, PropertyMock, patch
+
 from .models import Photo
 
 

--- a/tests/test_optimistic_strategy.py
+++ b/tests/test_optimistic_strategy.py
@@ -1,5 +1,10 @@
 from imagekit.cachefiles import ImageCacheFile
-from unittest.mock import Mock
+
+try:
+    from unittest.mock import Mock
+except:
+    from mock import Mock
+
 from .utils import create_image
 from django.core.files.storage import FileSystemStorage
 from imagekit.cachefiles.backends import Simple as SimpleCFBackend

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
+    py27-django111
     py{36,37,38,39,310}-django{22,31,32},
     py310-djangomain,
     coverage-report
 
 [gh-actions]
 python =
+    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38
@@ -15,6 +17,7 @@ python =
 [testenv]
 deps =
     -r test-requirements.txt
+    django111: django~=1.11.0
     django22: django~=2.2.0
     django31: django~=3.1.0
     django32: django~=3.2.0


### PR DESCRIPTION
force_text and smart_text were deprecated in Django 3.0 and are removed in Django 4.0