### PR TITLE
Properly close files after finish using them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ if 'publish' in sys.argv:
     sys.exit()
 
 
-read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
+def read(filepath):
+    with codecs.open(filepath, 'r', 'utf-8') as f:
+        return f.read()
 
 
 def exec_file(filepath, globalz=None, localz=None):

--- a/tests/test_cachefiles.py
+++ b/tests/test_cachefiles.py
@@ -109,8 +109,8 @@ def test_lazyfile_stringification():
     assert str(file) == ''
     assert repr(file) == '<ImageCacheFile: None>'
 
-    source_file = get_image_file()
-    file = LazyImageCacheFile('testspec', source=source_file)
+    with get_image_file() as source_file:
+        file = LazyImageCacheFile('testspec', source=source_file)
     file.name = 'a.jpg'
     assert str(file) == 'a.jpg'
     assert repr(file) == '<ImageCacheFile: a.jpg>'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -15,9 +15,9 @@ from .utils import get_image_file
 @pytest.mark.django_db(transaction=True)
 def test_model_processedimagefield():
     instance = ProcessedImageFieldModel()
-    file = File(get_image_file())
-    instance.processed.save('whatever.jpeg', file)
-    instance.save()
+    with File(get_image_file()) as file:
+        instance.processed.save('whatever.jpeg', file)
+        instance.save()
 
     assert instance.processed.width == 50
     assert instance.processed.height == 50
@@ -26,9 +26,9 @@ def test_model_processedimagefield():
 @pytest.mark.django_db(transaction=True)
 def test_model_processedimagefield_with_spec():
     instance = ProcessedImageFieldWithSpecModel()
-    file = File(get_image_file())
-    instance.processed.save('whatever.jpeg', file)
-    instance.save()
+    with File(get_image_file()) as file:
+        instance.processed.save('whatever.jpeg', file)
+        instance.save()
 
     assert instance.processed.width == 100
     assert instance.processed.height == 60
@@ -38,15 +38,19 @@ def test_model_processedimagefield_with_spec():
 def test_form_processedimagefield():
     class TestForm(forms.ModelForm):
         image = ikforms.ProcessedImageField(spec_id='tests:testform_image',
-                processors=[SmartCrop(50, 50)], format='JPEG')
+                                            processors=[SmartCrop(50, 50)],
+                                            format='JPEG')
 
         class Meta:
             model = ImageModel
             fields = 'image',
 
-    upload_file = get_image_file()
-    file_dict = {'image': SimpleUploadedFile('abc.jpg', upload_file.read())}
-    form = TestForm({}, file_dict)
+    with get_image_file() as upload_file:
+        files = {
+            'image': SimpleUploadedFile('abc.jpg', upload_file.read())
+        }
+
+    form = TestForm({}, files)
     instance = form.save()
 
     assert instance.image.width == 50

--- a/tests/test_sourcegroups.py
+++ b/tests/test_sourcegroups.py
@@ -26,7 +26,8 @@ def test_source_saved_signal():
     source_group = ImageFieldSourceGroup(ImageModel, 'image')
     receiver = make_counting_receiver(source_group)
     source_saved.connect(receiver)
-    ImageModel.objects.create(image=File(get_image_file(), name='reference.png'))
+    with File(get_image_file(), name='reference.png') as image:
+        ImageModel.objects.create(image=image)
     assert receiver.count == 1
 
 
@@ -56,5 +57,6 @@ def test_abstract_model_signals():
     source_group = ImageFieldSourceGroup(AbstractImageModel, 'original_image')
     receiver = make_counting_receiver(source_group)
     source_saved.connect(receiver)
-    ConcreteImageModel.objects.create(original_image=File(get_image_file(), name='reference.png'))
+    with File(get_image_file(), name='reference.png') as image:
+        ConcreteImageModel.objects.create(original_image=image)
     assert receiver.count == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,8 @@ def get_image_file():
 
 def get_unique_image_file():
     file = NamedTemporaryFile()
-    file.write(get_image_file().read())
+    with get_image_file() as image:
+        file.write(image.read())
     return file
 
 
@@ -60,10 +61,10 @@ def pickleback(obj):
 
 
 def render_tag(ttag):
-    img = get_image_file()
-    template = Template('{%% load imagekit %%}%s' % ttag)
-    context = Context({'img': img})
-    return template.render(context)
+    with get_image_file() as img:
+        template = Template('{%% load imagekit %%}%s' % ttag)
+        context = Context({'img': img})
+        return template.render(context)
 
 
 def get_html_attrs(ttag):


### PR DESCRIPTION
This change is mostly related to tests and setup.py.
On the imagekit's own code base all files are properly closed.