### PR TITLE
Fix: only seek files when possible

### DIFF
--- a/imagekit/cachefiles/__init__.py
+++ b/imagekit/cachefiles/__init__.py
@@ -102,7 +102,8 @@ class ImageCacheFile(BaseIKFile, ImageFile):
         actual_name = self.storage.save(self.name, content)
 
         # We're going to reuse the generated file, so we need to reset the pointer.
-        content.seek(0)
+        if not hasattr(content, "seekable") or content.seekable():
+            content.seek(0)
 
         # Store the generated file. If we don't do this, the next time the
         # "file" attribute is accessed, it will result in a call to the storage


### PR DESCRIPTION
Also fixes #517

After testing around a few things I found that the issue is only related to e.g. S3BotoStorage where the File object is not seekable. The image generation and content caching will still work as expected.