### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/_themes/README.rst
+++ b/docs/_themes/README.rst
@@ -2,7 +2,7 @@ krTheme Sphinx Style
 ====================
 
 This repository contains sphinx styles Kenneth Reitz uses in most of
-his projects. It is a drivative of Mitsuhiko's themes for Flask and Flask related
+his projects. It is a derivative of Mitsuhiko's themes for Flask and Flask related
 projects.  To use this style in your Sphinx documentation, follow
 this guide:
 

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -117,7 +117,7 @@ differently and for example do not cache values if timeout is ``None``.
 If you clear your cache durring deployment or some other reason probably
 you do not want to lose the cache for generated images especcialy if you
 are using some slow remote storage (like Amazon S3). Then you can configure
-seprate cache (for example redis) in your ``CACHES`` config and tell ImageKit
+separate cache (for example redis) in your ``CACHES`` config and tell ImageKit
 to use it instead of the default cache by setting ``IMAGEKIT_CACHE_BACKEND``.
 
 
@@ -180,7 +180,7 @@ Or, in Python:
 
     If you are using an "async" backend in combination with the "optimistic"
     cache file strategy (see `Removing Safeguards`_ below), checking for
-    thruthiness as described above will not work. The "optimistic" backend is
+    truthiness as described above will not work. The "optimistic" backend is
     very optimistic so to say, and removes the check. Create and use the
     following strategy to a) have images only created on save, and b) retain
     the ability to check whether the images have already been created::
@@ -211,7 +211,7 @@ operation. However, if the state isn't cached, ImageKit will need to query the
 storage backend.
 
 For those who aren't willing to accept that cost (and who never want ImageKit
-to generate images in the request-responce cycle), there's the "optimistic"
+to generate images in the request-response cycle), there's the "optimistic"
 cache file strategy. This strategy only generates a new image when a spec's
 source image is created or changed. Unlike with the "just in time" strategy,
 accessing the file won't cause it to be generated, ImageKit will just assume

--- a/imagekit/files.py
+++ b/imagekit/files.py
@@ -57,7 +57,7 @@ class BaseIKFile(File):
         try:
             self.file.open(mode)
         except ValueError:
-            # if the underlaying file can't be reopened
+            # if the underlying file can't be reopened
             # then we will use the storage to try to open it again
             if self.file.closed:
                 # clear cached file instance

--- a/imagekit/forms/fields.py
+++ b/imagekit/forms/fields.py
@@ -27,7 +27,7 @@ class ProcessedImageField(ImageField, SpecHost):
             spec = self.get_spec(source=data)
             f = generate(spec)
             # Name is required in Django 1.4. When we drop support for it
-            # then we can dirrectly return the result from `generate(spec)`
+            # then we can directly return the result from `generate(spec)`
             f.name = data.name
             return f
 

--- a/imagekit/specs/sourcegroups.py
+++ b/imagekit/specs/sourcegroups.py
@@ -130,7 +130,7 @@ class ModelSignalRouter:
 
 class ImageFieldSourceGroup:
     """
-    A source group that repesents a particular field across all instances of a
+    A source group that represents a particular field across all instances of a
     model and its subclasses.
 
     """

--- a/tests/test_optimistic_strategy.py
+++ b/tests/test_optimistic_strategy.py
@@ -30,7 +30,7 @@ def get_image_cache_file():
 def test_no_io_on_bool():
     """
     When checking the truthiness of an ImageCacheFile, the storage shouldn't
-    peform IO operations.
+    perform IO operations.
 
     """
     file = get_image_cache_file()


### PR DESCRIPTION
There are small typos in:
- docs/_themes/README.rst
- docs/caching.rst
- imagekit/files.py
- imagekit/forms/fields.py
- imagekit/specs/sourcegroups.py
- tests/test_optimistic_strategy.py

Fixes:
- Should read `underlying` rather than `underlaying`.
- Should read `truthiness` rather than `thruthiness`.
- Should read `separate` rather than `seprate`.
- Should read `response` rather than `responce`.
- Should read `represents` rather than `repesents`.
- Should read `perform` rather than `peform`.
- Should read `directly` rather than `dirrectly`.
- Should read `derivative` rather than `drivative`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md