### PR TITLE
Upgrade project to latest versions of python and django

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/imagekit/conf.py
+++ b/imagekit/conf.py
@@ -36,5 +36,8 @@ class ImageKitConf(AppConf):
 
     def configure_default_file_storage(self, value):
         if value is None:
-            value = settings.DEFAULT_FILE_STORAGE
+            try:
+                value = settings.STORAGES["default"]["BACKEND"]
+            except AttributeError:
+                value = settings.DEFAULT_FILE_STORAGE
         return value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,32 @@
+import django
+from django.test import override_settings
+import pytest
+from imagekit.conf import ImageKitConf, settings
+
+
+@pytest.mark.skipif(
+    django.VERSION < (4, 2),
+    reason="STORAGES was introduced in Django 4.2",
+)
+def test_custom_storages():
+    with override_settings(
+        STORAGES={
+            "default": {
+                "BACKEND": "tests.utils.CustomStorage",
+            }
+        },
+    ):
+        conf = ImageKitConf()
+        assert conf.configure_default_file_storage(None) == "tests.utils.CustomStorage"
+
+
+@pytest.mark.skipif(
+    django.VERSION >= (5, 1),
+    reason="DEFAULT_FILE_STORAGE is removed in Django 5.1.",
+)
+def test_custom_default_file_storage():
+    with override_settings(DEFAULT_FILE_STORAGE="tests.utils.CustomStorage"):
+        # If we don’t remove this, Django 4.2 will keep the old value.
+        del settings.STORAGES
+        conf = ImageKitConf()
+        assert conf.configure_default_file_storage(None) == "tests.utils.CustomStorage"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from tempfile import NamedTemporaryFile
 
 from bs4 import BeautifulSoup
 from django.core.files import File
+from django.core.files.storage import FileSystemStorage
 from django.template import Context, Template
 from PIL import Image
 
@@ -77,6 +78,10 @@ def assert_file_is_falsy(file):
 
 def assert_file_is_truthy(file):
     assert bool(file), 'File is not truthy'
+
+
+class CustomStorage(FileSystemStorage):
+    pass
 
 
 class DummyAsyncCacheFileBackend(Simple):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}-django{32,41,42},
-    py310-djangomain,
+    py37-django{32}
+    py38-django{42, 41, 32}
+    py39-django{42, 41, 32}
+    py310-django{42, 41, 32}
+    py311-django{42, 41}
+    py311-djangomain,
     coverage-report
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,23 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-django{22,31,32},
+    py{37,38,39,310,311}-django{32,41,42},
     py310-djangomain,
     coverage-report
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, coverage-report
+    3.10: py310
+    3.11: py311, coverage-report
 
 [testenv]
 deps =
     -r test-requirements.txt
-    django22: django~=2.2.0
-    django31: django~=3.1.0
     django32: django~=3.2.0
+    django41: django~=4.1.0
+    django42: django~=4.2.0
     djangomain: https://github.com/django/django/archive/refs/heads/main.zip
 
 setenv = COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
The main issue to fix is that the lib is currently not properly getting the default STORAGE backend if the project is already using the new 4.2 settings.

I also removed unsupported versions from tox and added the new ones.