### PR TITLE
AdminThumbnail: Use source from generator if image_field is a function

### DIFF
--- a/imagekit/admin.py
+++ b/imagekit/admin.py
@@ -23,14 +23,19 @@ class AdminThumbnail:
     def __call__(self, obj):
         if callable(self.image_field):
             thumbnail = self.image_field(obj)
+            generator = getattr(thumbnail, 'generator', None)
+            if generator:
+                original_image = getattr(generator, 'source', thumbnail)
+            else:
+                original_image = thumbnail
         else:
             try:
                 thumbnail = getattr(obj, self.image_field)
+                original_image = getattr(thumbnail, 'source', None) or thumbnail
             except AttributeError:
                 raise Exception('The property %s is not defined on %s.' %
                         (self.image_field, obj.__class__.__name__))
 
-        original_image = getattr(thumbnail, 'source', None) or thumbnail
         template = self.template or 'imagekit/admin/thumbnail.html'
 
         return render_to_string(template, {


### PR DESCRIPTION
My main motivation was this example from the readme: https://github.com/matthewwithanm/django-imagekit?tab=readme-ov-file#admin (_To use specs defined outside of models:_)

If you use this example code and click on the thumbnail image in the admin interface, the thumbnail image will open and not the original image. With this PR the original image will be opened. 