### PR TITLE
Remove ResourceWarning during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .tox
 .idea
 .vscode
+.coverage
+.coverage.*
+.venv
 MANIFEST
 build
 dist

--- a/tests/test_cachefiles.py
+++ b/tests/test_cachefiles.py
@@ -30,9 +30,10 @@ def test_sync_backend_truthiness():
     is truthy.
 
     """
-    spec = TestSpec(source=get_unique_image_file())
-    file = ImageCacheFile(spec)
-    assert_file_is_truthy(file)
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        assert_file_is_truthy(file)
 
 
 def test_async_backend_falsiness():
@@ -40,9 +41,10 @@ def test_async_backend_falsiness():
     Ensure that a cachefile with an asynchronous cache file backend is falsy.
 
     """
-    spec = TestSpec(source=get_unique_image_file())
-    file = ImageCacheFile(spec, cachefile_backend=DummyAsyncCacheFileBackend())
-    assert_file_is_falsy(file)
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec, cachefile_backend=DummyAsyncCacheFileBackend())
+        assert_file_is_falsy(file)
 
 
 def test_no_source_error():
@@ -68,13 +70,14 @@ def test_repr_does_not_send_existence_required():
         # import here to apply mock
         from imagekit.cachefiles import ImageCacheFile
 
-        spec = TestSpec(source=get_unique_image_file())
-        file = ImageCacheFile(
-            spec,
-            cachefile_backend=DummyAsyncCacheFileBackend()
-        )
-        file.__repr__()
-        assert signal.send.called is False
+        with get_unique_image_file() as source_file:
+            spec = TestSpec(source=source_file)
+            file = ImageCacheFile(
+                spec,
+                cachefile_backend=DummyAsyncCacheFileBackend()
+            )
+            file.__repr__()
+            assert signal.send.called is False
 
 
 def test_memcached_cache_key():
@@ -118,12 +121,13 @@ def test_lazyfile_stringification():
 
 
 def test_generate_file_already_exists(caplog):
-    spec = TestSpec(source=get_unique_image_file())
-    file_1 = ImageCacheFile(spec)
-    file_1._generate()
-    # generate another cache image with the same name
-    file_2 = ImageCacheFile(spec, name=file_1.name)
-    file_2._generate()
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file_1 = ImageCacheFile(spec)
+        file_1._generate()
+        # generate another cache image with the same name
+        file_2 = ImageCacheFile(spec, name=file_1.name)
+        file_2._generate()
 
     assert len(caplog.records) == 1
     storage, name, actual_name, cachefile_backend = caplog.records[0].args

--- a/tests/test_optimistic_strategy.py
+++ b/tests/test_optimistic_strategy.py
@@ -33,10 +33,10 @@ def test_no_io_on_bool():
     perform IO operations.
 
     """
-    file = get_image_cache_file()
-    bool(file)
-    assert not file.storage.exists.called
-    assert not file.storage.open.called
+    with get_image_cache_file() as file:
+        bool(file)
+        assert not file.storage.exists.called
+        assert not file.storage.open.called
 
 
 def test_no_io_on_url():
@@ -45,7 +45,7 @@ def test_no_io_on_url():
     checked.
 
     """
-    file = get_image_cache_file()
-    file.url
-    assert not file.storage.exists.called
-    assert not file.storage.open.called
+    with get_image_cache_file() as file:
+        file.url
+        assert not file.storage.exists.called
+        assert not file.storage.open.called

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -36,13 +36,14 @@ def test_circular_ref():
 
 def test_cachefiles():
     clear_imagekit_cache()
-    spec = TestSpec(source=get_unique_image_file())
-    file = ImageCacheFile(spec)
-    file.url
-    # remove link to file from spec source generator
-    # test __getstate__ of ImageCacheFile
-    file.generator.source = None
-    restored_file = pickleback(file)
-    assert file is not restored_file
-    # Assertion for #437 and #451
-    assert file.storage is restored_file.storage
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        file.url
+        # remove link to file from spec source generator
+        # test __getstate__ of ImageCacheFile
+        file.generator.source = None
+        restored_file = pickleback(file)
+        assert file is not restored_file
+        # Assertion for #437 and #451
+        assert file.storage is restored_file.storage


### PR DESCRIPTION
Properly close files during tests to prevent `ResourceWarning` from happening