### PR TITLE
feat: Add request-local state cache to reduce cache round trips

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -137,6 +137,45 @@ running the ``generateimages`` management command.
     If using with template tags, be sure to read :ref:`source-groups`.
 
 
+Reducing Cache Backend Round Trips
+----------------------------------
+
+When rendering pages with many images, ImageKit performs one cache lookup per image
+to check the cachefile state (so a page with 50 images can cause 50 cache round
+trips). This can become a major request latency problem, and is highly sensitive to
+the network latency to the cache.
+
+To reduce this overhead, ImageKit provides a set of APIs that can be used to prefetch
+cache states into a request-local state cache using a single ``cache.get_many()``
+call:
+
+.. code-block:: python
+
+    from imagekit.cachefiles.state import use_cachefile_state_cache, prefetch_cachefile_states
+
+    def gallery(request):
+        images = list(Image.objects.filter(...)[:50])
+
+        # Construct ImageCacheFile objects. (No cache request yet)
+        thumbs = [img.thumbnail for img in images]
+
+        # Create a request-local mapping and prefetch states
+        state_cache = {}
+        with use_cachefile_state_cache(state_cache):
+            prefetch_cachefile_states(thumbs, state_cache=state_cache)
+            return render(request, "gallery.html", {"images": images})
+
+How it works:
+
+1. ``use_cachefile_state_cache()`` activates a request-local in-memory cache
+   for the duration of the context (a plain dict is typically used).
+2. ``prefetch_cachefile_states()`` fetches all cache file states in a single
+   ``cache.get_many()`` call and stores them in the state cache.
+3. During template rendering, ``ImageCacheFile.url`` accesses check the state
+   cache first before calling ``cache.get()``, so prefetched keys incur no
+   additional cache round trips.
+
+
 Deferring Image Generation
 --------------------------
 

--- a/imagekit/cachefiles/backends.py
+++ b/imagekit/cachefiles/backends.py
@@ -4,6 +4,7 @@ from copy import copy
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from .state import get_active_state_cache
 from ..utils import get_cache, get_singleton, sanitize_cache_key
 
 
@@ -65,7 +66,17 @@ class CachedFileBackend:
 
     def get_state(self, file, check_if_unknown=True):
         key = self.get_key(file)
-        state = self.cache.get(key)
+
+        # Check request-local state cache first
+        state_cache = get_active_state_cache()
+        if state_cache is not None and key in state_cache:
+            state = state_cache[key]
+        else:
+            state = self.cache.get(key)
+            # Write-through to request-local cache if active
+            if state_cache is not None:
+                state_cache[key] = state
+
         if state is None and check_if_unknown:
             exists = self._exists(file)
             state = CacheFileState.EXISTS if exists else CacheFileState.DOES_NOT_EXIST
@@ -78,6 +89,11 @@ class CachedFileBackend:
             self.cache.set(key, state, self.existence_check_timeout)
         else:
             self.cache.set(key, state, settings.IMAGEKIT_CACHE_TIMEOUT)
+
+        # Write-through to request-local state cache if active
+        state_cache = get_active_state_cache()
+        if state_cache is not None:
+            state_cache[key] = state
 
     def __getstate__(self):
         state = copy(self.__dict__)

--- a/imagekit/cachefiles/state.py
+++ b/imagekit/cachefiles/state.py
@@ -1,0 +1,114 @@
+"""
+Request-local state cache for ImageKit cachefiles to reduce cache lookups.
+
+This module provides an optional request-local in-memory state cache that can
+be used to batch prefetch cache file states, reducing round trips to the Django
+cache backend.
+"""
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# ContextVar for storing the active state cache (a dict-like mapping) for the
+# current execution context.
+_active_state_cache: ContextVar = ContextVar('_active_state_cache', default=None)
+
+
+@contextmanager
+def use_cachefile_state_cache(state_cache=None):
+    """
+    Context manager to activate a request-local state cache.
+
+    Usage::
+
+        from imagekit.cachefiles.state import use_cachefile_state_cache, prefetch_cachefile_states
+
+        state_cache = {}
+        with use_cachefile_state_cache(state_cache):
+            prefetch_cachefile_states(thumbs, state_cache=state_cache)
+            # ... render template with thumbs ...
+
+    :param state_cache: A dict-like mapping to use as the cache.
+        If None, a new empty dict will be created.
+    """
+    if state_cache is None:
+        state_cache = {}
+
+    token = _active_state_cache.set(state_cache)
+    try:
+        yield state_cache
+    finally:
+        _active_state_cache.reset(token)
+
+
+def get_active_state_cache():
+    """
+    Get the active state cache for the current context, if any.
+
+    :return: The active dict-like mapping, or None if no cache is active.
+    """
+    return _active_state_cache.get(None)
+
+
+def prefetch_cachefile_states(files, *, state_cache=None, cache=None):
+    """
+    Prefetch cache file states using cache.get_many().
+
+    This function computes cache keys for the given files and fetches their
+    states in as few cache.get_many() calls as possible. The results are stored
+    in the provided state_cache (or the active request-local cache if not
+    provided).
+
+    Example usage in a view::
+
+        from imagekit.cachefiles.state import use_cachefile_state_cache, prefetch_cachefile_states
+
+        def gallery(request):
+            images = list(Image.objects.filter(...))
+            thumbs = [img.thumbnail for img in images]
+
+            state_cache = {}
+            with use_cachefile_state_cache(state_cache):
+                prefetch_cachefile_states(thumbs, state_cache=state_cache)
+                return render(request, "gallery.html", {"images": images})
+
+    :param files: Iterable of ImageCacheFile objects to prefetch states for.
+    :param state_cache: Optional dict-like mapping to populate. If None,
+        the active request-local cache will be used (if any).
+    :param cache: Optional Django cache instance. If provided, all lookups
+        will use this cache. If None, each file's cachefile backend will
+        determine which cache to read from.
+    """
+    from .backends import CachedFileBackend
+
+    if state_cache is None:
+        state_cache = get_active_state_cache()
+        if state_cache is None:
+            return
+
+    # Group keys by the Django cache object used for the lookup.
+    keys_by_cache = {}
+
+    for f in files:
+        backend = getattr(f, 'cachefile_backend', None)
+        if not isinstance(backend, CachedFileBackend):
+            continue
+
+        key = backend.get_key(f)
+
+        backend_cache = cache or backend.cache
+        keys_by_cache.setdefault(backend_cache, set()).add(key)
+
+    if not keys_by_cache:
+        return
+
+    for backend_cache, keys in keys_by_cache.items():
+        states = backend_cache.get_many(keys)
+
+        # Store hits in state_cache
+        for key, state in states.items():
+            state_cache[key] = state
+
+        # Also record misses so later checks don't fall back to cache.get()
+        for key in keys:
+            if key not in states:
+                state_cache[key] = None

--- a/tests/test_state_cache.py
+++ b/tests/test_state_cache.py
@@ -1,0 +1,315 @@
+"""
+Tests for request-local state cache functionality.
+"""
+from unittest import mock
+import pytest
+
+from django.conf import settings
+
+from imagekit.cachefiles import ImageCacheFile
+from imagekit.cachefiles.backends import Simple, CachedFileBackend, CacheFileState
+from imagekit.cachefiles.state import use_cachefile_state_cache, prefetch_cachefile_states
+
+from .imagegenerators import TestSpec, ResizeTo1PixelSquare
+from .utils import get_unique_image_file, clear_imagekit_cache
+
+
+def test_get_state_uses_request_local_cache_without_hitting_django_cache():
+    """
+    Ensure get_state() consults request-local cache first and doesn't call
+    Django cache.get() for pre-seeded keys.
+    """
+    clear_imagekit_cache()
+
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        backend = file.cachefile_backend
+
+        # Spy on cache.get
+        cache_get = mock.patch.object(backend.cache, 'get')
+
+        with cache_get as mock_get:
+            # First call - should hit cache
+            mock_get.return_value = CacheFileState.DOES_NOT_EXIST
+            state1 = backend.get_state(file)
+            assert state1 == CacheFileState.DOES_NOT_EXIST
+            assert mock_get.call_count == 1
+
+            # Now activate request-local cache and pre-seed it
+            state_cache = {backend.get_key(file): CacheFileState.EXISTS}
+            with use_cachefile_state_cache(state_cache):
+                mock_get.reset_mock()
+                # Should get state from request-local cache, not Django cache
+                state2 = backend.get_state(file)
+                assert state2 == CacheFileState.EXISTS
+                assert mock_get.call_count == 0
+
+
+def test_get_state_with_unknown_state_still_updates_request_local_cache():
+    """
+    Ensure get_state() with check_if_unknown=True stores newly discovered
+    state in the request-local cache.
+    """
+    clear_imagekit_cache()
+
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        backend = file.cachefile_backend
+
+        state_cache = {}
+        with use_cachefile_state_cache(state_cache):
+            # First call with check_if_unknown=True (file doesn't exist yet)
+            # This should call cache.get() (returns None), check storage,
+            # and store DOES_NOT_EXIST in both Django cache and request-local cache
+            state = backend.get_state(file)
+            assert state == CacheFileState.DOES_NOT_EXIST
+
+            # Verify request-local cache was updated
+            key = backend.get_key(file)
+            assert key in state_cache
+            assert state_cache[key] == CacheFileState.DOES_NOT_EXIST
+
+
+def test_prefetch_cachefile_states_uses_get_many_once_and_populates_mapping():
+    """
+    Ensure prefetch_cachefile_states() calls cache.get_many() once and
+    populates the state_cache with both hits and misses.
+    """
+    clear_imagekit_cache()
+
+    # Create multiple files with different specs to get unique cache keys
+    files = []
+
+    # Create 3 different specs with different sources
+    for _ in range(3):
+        with get_unique_image_file() as source_file:
+            spec = TestSpec(source=source_file)
+            file = ImageCacheFile(spec)
+            files.append(file)
+
+    backend = files[0].cachefile_backend
+
+    # Prefetch states - use the actual backend cache
+    state_cache = {}
+    prefetch_cachefile_states(files, cache=backend.cache, state_cache=state_cache)
+
+    # Verify state_cache was populated with all unique keys
+    assert len(state_cache) == 3
+
+    # All should be None (misses) since no states are in the cache
+    for key, value in state_cache.items():
+        assert value is None
+
+
+def test_prefetch_uses_active_request_local_cache_when_none_provided():
+    """
+    Ensure prefetch_cachefile_states() uses active request-local cache
+    when state_cache parameter is not provided.
+    """
+    clear_imagekit_cache()
+
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        backend = file.cachefile_backend
+
+        key = backend.get_key(file)
+
+        with mock.patch.object(backend.cache, 'get_many') as mock_get_many:
+            mock_get_many.return_value = {key: CacheFileState.EXISTS}
+
+            # Activate request-local cache
+            with use_cachefile_state_cache() as state_cache:
+                prefetch_cachefile_states([file])
+
+                # Verify active cache was populated
+                assert key in state_cache
+                assert state_cache[key] == CacheFileState.EXISTS
+
+
+def test_prefetch_does_nothing_when_no_active_cache_and_none_provided():
+    """
+    Ensure prefetch_cachefile_states() is a no-op when no state_cache is
+    provided and no active request-local cache exists.
+    """
+    clear_imagekit_cache()
+
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        backend = file.cachefile_backend
+
+        with mock.patch.object(backend.cache, 'get_many') as mock_get_many:
+            prefetch_cachefile_states([file])
+
+            # Should not call get_many since there's no cache to populate
+            assert mock_get_many.call_count == 0
+
+
+def test_set_state_updates_request_local_cache():
+    """
+    Ensure set_state() updates the active request-local cache (write-through).
+    """
+    clear_imagekit_cache()
+
+    with get_unique_image_file() as source_file:
+        spec = TestSpec(source=source_file)
+        file = ImageCacheFile(spec)
+        backend = file.cachefile_backend
+
+        state_cache = {}
+        with use_cachefile_state_cache(state_cache):
+            # Set state
+            backend.set_state(file, CacheFileState.GENERATING)
+
+            # Verify request-local cache was updated
+            key = backend.get_key(file)
+            assert key in state_cache
+            assert state_cache[key] == CacheFileState.GENERATING
+
+
+def test_multiple_get_state_calls_only_hit_cache_once_after_prefetch():
+    """
+    Ensure that after prefetching, multiple get_state() calls don't hit
+    the Django cache.
+    """
+    clear_imagekit_cache()
+
+    # Create multiple files
+    files = []
+    with get_unique_image_file() as source_file:
+        for i in range(5):
+            spec = TestSpec(source=source_file)
+            file = ImageCacheFile(spec)
+            files.append(file)
+
+    backend = files[0].cachefile_backend
+
+    with mock.patch.object(backend.cache, 'get') as mock_get, \
+         mock.patch.object(backend.cache, 'get_many') as mock_get_many:
+        # Set up get_many to return all files as existing
+        keys = [backend.get_key(f) for f in files]
+        mock_get_many.return_value = {k: CacheFileState.EXISTS for k in keys}
+
+        # Activate request-local cache and prefetch
+        with use_cachefile_state_cache() as state_cache:
+            prefetch_cachefile_states(files, state_cache=state_cache)
+
+            # Mock get_many should have been called once
+            assert mock_get_many.call_count == 1
+            assert mock_get.call_count == 0
+
+            # Now call get_state for each file multiple times
+            for _ in range(3):
+                for file in files:
+                    state = backend.get_state(file)
+                    assert state == CacheFileState.EXISTS
+
+            # Verify no additional cache.get() calls
+            assert mock_get.call_count == 0
+
+
+def test_prefetch_groups_by_backend_cache_when_cache_not_provided():
+    """
+    Ensure prefetch_cachefile_states() uses each file's backend cache when
+    no explicit cache is passed.
+
+    This supports projects that mix cachefile backends (and potentially cache
+    aliases).
+    """
+    clear_imagekit_cache()
+
+    cache_a = mock.Mock()
+    cache_b = mock.Mock()
+
+    backend_a = CachedFileBackend()
+    backend_b = CachedFileBackend()
+
+    backend_a._cache = cache_a
+    backend_b._cache = cache_b
+
+    with get_unique_image_file() as source_file_a, get_unique_image_file() as source_file_b:
+        spec_a = TestSpec(source=source_file_a)
+        spec_b = TestSpec(source=source_file_b)
+
+        file_a = ImageCacheFile(spec_a, cachefile_backend=backend_a)
+        file_b = ImageCacheFile(spec_b, cachefile_backend=backend_b)
+
+        key_a = backend_a.get_key(file_a)
+        key_b = backend_b.get_key(file_b)
+
+        cache_a.get_many.return_value = {key_a: CacheFileState.EXISTS}
+        cache_b.get_many.return_value = {key_b: CacheFileState.GENERATING}
+
+        state_cache = {}
+        prefetch_cachefile_states([file_a, file_b], state_cache=state_cache)
+
+        cache_a.get_many.assert_called_once_with({key_a})
+        cache_b.get_many.assert_called_once_with({key_b})
+
+        assert state_cache[key_a] == CacheFileState.EXISTS
+        assert state_cache[key_b] == CacheFileState.GENERATING
+
+
+def test_prefetch_uses_provided_cache_for_all_backends():
+    """Ensure the `cache=` kwarg overrides per-backend caches."""
+    clear_imagekit_cache()
+
+    shared_cache = mock.Mock()
+
+    cache_a = mock.Mock()
+    cache_b = mock.Mock()
+
+    backend_a = CachedFileBackend()
+    backend_b = CachedFileBackend()
+
+    backend_a._cache = cache_a
+    backend_b._cache = cache_b
+
+    with get_unique_image_file() as source_file_a, get_unique_image_file() as source_file_b:
+        spec_a = TestSpec(source=source_file_a)
+        spec_b = TestSpec(source=source_file_b)
+
+        file_a = ImageCacheFile(spec_a, cachefile_backend=backend_a)
+        file_b = ImageCacheFile(spec_b, cachefile_backend=backend_b)
+
+        key_a = backend_a.get_key(file_a)
+        key_b = backend_b.get_key(file_b)
+
+        shared_cache.get_many.return_value = {
+            key_a: CacheFileState.EXISTS,
+            key_b: CacheFileState.EXISTS,
+        }
+
+        state_cache = {}
+        prefetch_cachefile_states([file_a, file_b], cache=shared_cache, state_cache=state_cache)
+
+        shared_cache.get_many.assert_called_once_with({key_a, key_b})
+        assert cache_a.get_many.call_count == 0
+        assert cache_b.get_many.call_count == 0
+
+        assert state_cache[key_a] == CacheFileState.EXISTS
+        assert state_cache[key_b] == CacheFileState.EXISTS
+
+
+def test_use_cachefile_state_cache_creates_new_dict_if_none_provided():
+    """
+    Ensure use_cachefile_state_cache() creates a new dict if None is passed.
+    """
+    clear_imagekit_cache()
+
+    with use_cachefile_state_cache() as state_cache:
+        # Should get a dict
+        assert isinstance(state_cache, dict)
+        # Should be empty
+        assert len(state_cache) == 0
+
+        # Can add values
+        state_cache['test_key'] = 'test_value'
+        assert state_cache['test_key'] == 'test_value'
+
+    # After context exit, the cache should no longer be active
+    from imagekit.cachefiles.state import get_active_state_cache
+    assert get_active_state_cache() is None


### PR DESCRIPTION
When rendering pages with many images, ImageKit performs one cache lookup per image to check the cachefile state (so a page with 50 images can cause 50 cache round trips). This can become a major request latency problem, and is highly sensitive to the network latency to the cache.

To reduce this overhead, introduce an optional in-memory request-local cache for cachefile states, plus a prefetch helper using cache.get_many(). This reduces cache round trips when rendering pages with many images and helps avoid request latency spikes with remote cache backends.

Documentation and tests are added to cover the new behavior.